### PR TITLE
Correct capitalization in PaschalHours.xml

### DIFF
--- a/Ponomar/languages/xml/Services/PaschalHours.xml
+++ b/Ponomar/languages/xml/Services/PaschalHours.xml
@@ -12,7 +12,7 @@
 <CREATE What="EasterTropar81" Who="" RedFirst="1" NewLine="1" Header="1"/>
 <CREATE What="GloryToTheFather2" Who="R" RedFirst="1" NewLine="1"/>
 <CREATE What="EasterTropar82" Who="" RedFirst="1" NewLine="1" Header="1"/>
-<CREATE What="BothNow" Who="c" RedFirst="1" NewLine="1" />
+<CREATE What="BothNow" Who="C" RedFirst="1" NewLine="1" />
 <CREATE What="EasterTropar83" Who="" RedFirst="1" NewLine="1" Header="1"/>
 <CREATE What="LordHaveMercy" Who="R" RedFirst="1" NewLine="1" Times="40"/>
 <CREATE What="GloryToTheFather1" Who="R" RedFirst="1" NewLine="1"/>


### PR DESCRIPTION
This fixes a FileNotFoundException in Linux. File names are case sensitive in Linux, which means "c.xml" isn't found.