### PR TITLE
Fix Brenton LXX Genesis

### DIFF
--- a/Ponomar/languages/en/bible/brenton/Gen.text
+++ b/Ponomar/languages/en/bible/brenton/Gen.text
@@ -1,1634 +1,1632 @@
 
 #1
-1|  In the beginning God made the heaven and the earth. 
-2| But the earth was unsightly and unfurnished, and darkness was over the deep, and the Spirit of God moved over the water.
- 3| And God said, Let there be light, and there was light. 
-4| And God saw the light that it was good, and God divided between the light and the darkness. 
-5| And God called the light Day, and the darkness he called Night, and there was evening and there was morning, the first day. 	
-6| And God said, Let there be a firmament in the midst of the water, and let it be a division between water and water, and it was so. 
-7| And God made the firmament, and God divided between the water which was under the firmament and the water which was above the firmament. 
-8| And God called the firmament Heaven, and God saw that it was good, and there was evening and there was morning, the second day. 	
-9| And God said, Let the water which is under the heaven be collected into one place, and let the dry land appear, and it was so. And the water which was under the heaven was collected into its places, and the dry land appeared. 
-10| And God called the dry land Earth, and the gatherings of the waters he called Seas, and God saw that it was good. 
-11| And God said, Let the earth bring forth the herb of grass bearing seed according to its kind and according to its likeness, and the fruit-tree bearing fruit whose seed is in it, according to its kind on the earth, and it was so. 
-12| And the earth brought forth the herb of grass bearing seed according to its kind and according to its likeness, and the fruit tree bearing fruit whose seed is in it, according to its kind on the earth, and God saw that it was good. 
-13| And there was evening and there was morning, the third day. 	
-14| And God said, Let there be lights in the firmament of the heaven to give light upon the earth, to divide between day and night, and let them be for signs and for seasons and for days and for years. 
-15| And let them be for light in the firmament of the heaven, so as to shine upon the earth, and it was so. 
-16| And God made the two great lights, the greater light for regulating the day and the lesser light for regulating the night, the stars also. 
-17| And God placed them in the firmament of the heaven, so as to shine upon the earth, 
-18| and to regulate day and night, and to divide between the light and the darkness. And God saw that it was good. 
-19| And there was evening and there was morning, the fourth day. 	
-20| And God said, Let the waters bring forth reptiles having life, and winged creatures flying above the earth in the firmament of heaven, and it was so. 
-21| And God made great whales, and every living reptile, which the waters brought forth according to their kinds, and every creature that flies with wings according to its kind, and God saw that they were good. 
-22| And God blessed them saying, Increase and multiply and fill the waters in the seas, and let the creatures that fly be multiplied on the earth. 
-23| And there was evening and there was morning, the fifth day. 	
-24| And God said, Let the earth bring forth the living creature according to its kind, quadrupeds and reptiles and wild beasts of the earth according to their kind, and it was so. 
-25| And God made the wild beasts of the earth according to their kind, and cattle according to their kind, and all the reptiles of the earth according to their kind, and God saw that they were good. 	
-26| And God said, Let us make man according to our image and likeness, and let them have dominion over the fish of the sea, and over the flying creatures of heaven, and over the cattle and all the earth, and over all the reptiles that creep on the earth. 
-27| And God made man, according to the image of God he made him, male and female he made them. 
-28| And God blessed them, saying, Increase and multiply, and fill the earth and subdue it, and have dominion over the fish of the seas and flying creatures of heaven, and all the cattle and all the earth, and all the reptiles that creep on the earth. 
-29| And God said, Behold I have given to you every seed-bearing herb sowing seed which is upon all the earth, and every tree which has in itself the fruit of seed that is sown, to you it shall be for food. 
-30| And to all the wild beasts of the earth, and to all the flying creatures of heaven, and to every reptile creeping on the earth, which has in itself the breath of life, even every green plant for food; and it was so.
- 31| And God saw all the things that he had made, and, behold, they were very good. And there was evening and there was morning, the sixth day. 	 	
+1|In the beginning God made the heaven and the earth.
+2|But the earth was unsightly and unfurnished, and darkness was over the deep, and the Spirit of God moved over the water.
+3|And God said, Let there be light, and there was light.
+4|And God saw the light that it was good, and God divided between the light and the darkness.
+5|And God called the light Day, and the darkness he called Night, and there was evening and there was morning, the first day.
+6|And God said, Let there be a firmament in the midst of the water, and let it be a division between water and water, and it was so.
+7|And God made the firmament, and God divided between the water which was under the firmament and the water which was above the firmament.
+8|And God called the firmament Heaven, and God saw that it was good, and there was evening and there was morning, the second day.
+9|And God said, Let the water which is under the heaven be collected into one place, and let the dry land appear, and it was so. And the water which was under the heaven was collected into its places, and the dry land appeared.
+10|And God called the dry land Earth, and the gatherings of the waters he called Seas, and God saw that it was good.
+11|And God said, Let the earth bring forth the herb of grass bearing seed according to its kind and according to its likeness, and the fruit-tree bearing fruit whose seed is in it, according to its kind on the earth, and it was so.
+12|And the earth brought forth the herb of grass bearing seed according to its kind and according to its likeness, and the fruit tree bearing fruit whose seed is in it, according to its kind on the earth, and God saw that it was good.
+13|And there was evening and there was morning, the third day.
+14|And God said, Let there be lights in the firmament of the heaven to give light upon the earth, to divide between day and night, and let them be for signs and for seasons and for days and for years.
+15|And let them be for light in the firmament of the heaven, so as to shine upon the earth, and it was so.
+16|And God made the two great lights, the greater light for regulating the day and the lesser light for regulating the night, the stars also.
+17|And God placed them in the firmament of the heaven, so as to shine upon the earth,
+18|and to regulate day and night, and to divide between the light and the darkness. And God saw that it was good.
+19|And there was evening and there was morning, the fourth day.
+20|And God said, Let the waters bring forth reptiles having life, and winged creatures flying above the earth in the firmament of heaven, and it was so.
+21|And God made great whales, and every living reptile, which the waters brought forth according to their kinds, and every creature that flies with wings according to its kind, and God saw that they were good.
+22|And God blessed them saying, Increase and multiply and fill the waters in the seas, and let the creatures that fly be multiplied on the earth.
+23|And there was evening and there was morning, the fifth day.
+24|And God said, Let the earth bring forth the living creature according to its kind, quadrupeds and reptiles and wild beasts of the earth according to their kind, and it was so.
+25|And God made the wild beasts of the earth according to their kind, and cattle according to their kind, and all the reptiles of the earth according to their kind, and God saw that they were good.
+26|And God said, Let us make man according to our image and likeness, and let them have dominion over the fish of the sea, and over the flying creatures of heaven, and over the cattle and all the earth, and over all the reptiles that creep on the earth.
+27|And God made man, according to the image of God he made him, male and female he made them.
+28|And God blessed them, saying, Increase and multiply, and fill the earth and subdue it, and have dominion over the fish of the seas and flying creatures of heaven, and all the cattle and all the earth, and all the reptiles that creep on the earth.
+29|And God said, Behold I have given to you every seed-bearing herb sowing seed which is upon all the earth, and every tree which has in itself the fruit of seed that is sown, to you it shall be for food.
+30|And to all the wild beasts of the earth, and to all the flying creatures of heaven, and to every reptile creeping on the earth, which has in itself the breath of life, even every green plant for food; and it was so.
+31|And God saw all the things that he had made, and, behold, they were very good. And there was evening and there was morning, the sixth day.
 
 #2
-1| And the heavens and the earth were finished, and the whole world of them.  	
-2| And God finished on the sixth day his works which he made, and he ceased on the seventh day from all his works which he made. 
-3| And God blessed the seventh day and sanctified it, because in it he ceased from all his works which God began to do. 	
-4| This <i>is</i> the book of the generation of heaven and earth, when they were made, in the day in which the Lord God made the heaven and the earth, 
-5| and every herb of the field before it was on the earth, and all the grass of the field before it sprang up, for God had not rained on the earth, and there was not a man to cultivate it. 
-6| But there rose a fountain out of the earth, and watered the whole face of the earth. 
-7| And God formed the man <i>of</i> dust of the earth, and breathed upon his face the breath of life, and the man became a living soul. 	
-8| And God planted a garden eastward in Edem, and placed there the man whom he had formed. 
-9| And God made to spring up also out of the earth every tree beautiful to the eye and good for food, and the tree of life in the midst of the garden, and the tree of learning the knowledge of good and evil. 
-10| And a river proceeds out of Edem to water the garden, thence it divides itself into four heads. 
-11| The name of the one, Phisom, this it is which encircles the whole land of Evilat, where there is gold. 
-12| And the gold of that land is good, there also is carbuncle and emerald. 
-13| And the name of the second river is Geon, this it is which encircles the whole land of Ethiopia. 
-14| And the third river is Tigris, this is that which flows forth over against the Assyrians. And the fourth river is Euphrates. 
-15| And the Lord God took the man whom he had formed, and placed him in the garden of Delight, to cultivate and keep it.
- 16| And the Lord God gave a charge to Adam, saying, Of every tree which is in the garden thou mayest freely eat, 
-17| but of the tree of the knowledge of good and evil—of it ye shall not eat, but in whatsoever day ye eat of it, ye shall surely die. 	
-18| And the Lord God said, <i>It is</i> not good that the man should be alone, let us make for him a help suitable to him. 
-19| And God formed yet farther out of the earth all the wild beasts of the field, and all the birds of the sky, and he brought them to Adam, to see what he would call them, and whatever Adam called any living creature, that was the name of it. 
-20| And Adam gave names to all the cattle and to all the birds of the sky, and to all the wild beasts of the field, but for Adam there was not found a help like to himself.
- 21| And God brought a trance upon Adam, and he slept, and he took one of his ribs, and filled up the flesh instead thereof. 
-22| And God formed the rib which he took from Adam into a woman, and brought her to Adam. 
-23| And Adam said, This now is bone of my bones, and flesh of my flesh; she shall be called woman, because she was taken out of her husband. 
-24| Therefore shall a man leave his father and his mother and shall cleave to his wife, and they two shall be one flesh.  	 	
+1|And the heavens and the earth were finished, and the whole world of them.
+2|And God finished on the sixth day his works which he made, and he ceased on the seventh day from all his works which he made.
+3|And God blessed the seventh day and sanctified it, because in it he ceased from all his works which God began to do.
+4|This <i>is</i> the book of the generation of heaven and earth, when they were made, in the day in which the Lord God made the heaven and the earth,
+5|and every herb of the field before it was on the earth, and all the grass of the field before it sprang up, for God had not rained on the earth, and there was not a man to cultivate it.
+6|But there rose a fountain out of the earth, and watered the whole face of the earth.
+7|And God formed the man <i>of</i> dust of the earth, and breathed upon his face the breath of life, and the man became a living soul.
+8|And God planted a garden eastward in Edem, and placed there the man whom he had formed.
+9|And God made to spring up also out of the earth every tree beautiful to the eye and good for food, and the tree of life in the midst of the garden, and the tree of learning the knowledge of good and evil.
+10|And a river proceeds out of Edem to water the garden, thence it divides itself into four heads.
+11|The name of the one, Phisom, this it is which encircles the whole land of Evilat, where there is gold.
+12|And the gold of that land is good, there also is carbuncle and emerald.
+13|And the name of the second river is Geon, this it is which encircles the whole land of Ethiopia.
+14|And the third river is Tigris, this is that which flows forth over against the Assyrians. And the fourth river is Euphrates.
+15|And the Lord God took the man whom he had formed, and placed him in the garden of Delight, to cultivate and keep it.
+16|And the Lord God gave a charge to Adam, saying, Of every tree which is in the garden thou mayest freely eat,
+17|but of the tree of the knowledge of good and evil—of it ye shall not eat, but in whatsoever day ye eat of it, ye shall surely die.
+18|And the Lord God said, <i>It is</i> not good that the man should be alone, let us make for him a help suitable to him.
+19|And God formed yet farther out of the earth all the wild beasts of the field, and all the birds of the sky, and he brought them to Adam, to see what he would call them, and whatever Adam called any living creature, that was the name of it.
+20|And Adam gave names to all the cattle and to all the birds of the sky, and to all the wild beasts of the field, but for Adam there was not found a help like to himself.
+21|And God brought a trance upon Adam, and he slept, and he took one of his ribs, and filled up the flesh instead thereof.
+22|And God formed the rib which he took from Adam into a woman, and brought her to Adam.
+23|And Adam said, This now is bone of my bones, and flesh of my flesh; she shall be called woman, because she was taken out of her husband.
+24|Therefore shall a man leave his father and his mother and shall cleave to his wife, and they two shall be one flesh.
 
 #3
-1|  And the two were naked, both Adam and his wife, and were not ashamed.
-|  	
-3:2|  Now the serpent was the most crafty of all the brutes on the earth, which the Lord God made, and the serpent said to the woman, Wherefore has God said, Eat not of every tree of the garden? 
-3| And the woman said to the serpent, We may eat of the fruit of the trees of the garden, 
-4| but of the fruit of the tree which is in the midst of the garden, God said, Ye shall not eat of it, neither shall ye touch it, lest ye die. 
-5| And the serpent said to the woman, Ye shall not surely die. 
-6| For God knew that in whatever day ye should eat of it your eyes would be opened, and ye would be as gods, knowing good and evil. 
-7| And the woman saw that the tree was good for food, and that it was pleasant to the eyes to look upon and beautiful to contemplate, and having taken of its fruit she ate, and she gave to her husband also with her, and they ate. 
-8|  And the eyes of both were opened, and they perceived that they were naked, and they sewed fig leaves together, and made themselves aprons to go round them.  	
-9| And they heard the voice of the Lord God walking in the garden in the afternoon; and both Adam and his wife hid themselves from the face of the Lord God in the midst of the trees of the garden.
- 10|  And the Lord God called Adam and said to him, Adam, where art thou? 
-11|  And he said to him, I heard thy voice as thou walkedst in the garden, and I feared because I was naked and I hid myself.
- 12| And God said to him, Who told thee that thou wast naked, unless thou hast eaten of the tree concerning which I charged thee of it alone not to eat? 
-13| And Adam said, The woman whom thou gavest to be with me—she gave me of the tree and I ate. 
-14|  And the Lord God said to the woman, Why hast thou done this? And the woman said, The serpent deceived me and I ate. 	
-15| And the Lord God said to the serpent, Because thou hast done this thou art cursed above all cattle and all the brutes of the earth, on thy breast and belly thou shalt go, and thou shalt eat earth all the days of thy life. 
-16|  And I will put enmity between thee and the woman and between thy seed and her seed, he shall watch against thy head, and thou shalt watch against his heel.
- 17| And to the woman he said, I will greatly multiply thy pains and thy groanings; in pain thou shalt bring forth children, and thy submission shall be to thy husband, and he shall rule over thee. 
-18| And to Adam he said, Because thou hast hearkened to the voice of thy wife, and eaten of the tree concerning which I charged thee of it only not to eat—of that thou hast eaten, cursed <i>is</i> the ground in thy labours, in pain shalt thou eat of it all the days of thy life. 
-19|  Thorns and thistles shall it bring forth to thee, and thou shalt eat the herb of the field. 
-20|  In the sweat of thy face shalt thou eat thy bread until thou return to the earth out of which thou wast taken, for earth thou art and to earth thou shalt return.
- 21| And Adam called the name of his wife Life, because she was the mother of all living.
- 22|  And the Lord God made for Adam and his wife garments of skin, and clothed them. 	
-23| And God said, Behold, Adam is become as one of us, to know good and evil, and now lest at any time he stretch forth his hand, and take of the tree of life and eat, and <i>so</i> he shall live forever— 
-24| So the Lord God sent him forth out of the garden of Delight to cultivate the ground out of which he was taken. 
-25| And he cast out Adam and caused him to dwell over against the garden of Delight, and stationed the cherubs and the fiery sword that turns about to keep the way of the tree of life. 	 	
+1|And the two were naked, both Adam and his wife, and were not ashamed.
+2|Now the serpent was the most crafty of all the brutes on the earth, which the Lord God made, and the serpent said to the woman, Wherefore has God said, Eat not of every tree of the garden?
+3|And the woman said to the serpent, We may eat of the fruit of the trees of the garden,
+4|but of the fruit of the tree which is in the midst of the garden, God said, Ye shall not eat of it, neither shall ye touch it, lest ye die.
+5|And the serpent said to the woman, Ye shall not surely die.
+6|For God knew that in whatever day ye should eat of it your eyes would be opened, and ye would be as gods, knowing good and evil.
+7|And the woman saw that the tree was good for food, and that it was pleasant to the eyes to look upon and beautiful to contemplate, and having taken of its fruit she ate, and she gave to her husband also with her, and they ate.
+8|And the eyes of both were opened, and they perceived that they were naked, and they sewed fig leaves together, and made themselves aprons to go round them.
+9|And they heard the voice of the Lord God walking in the garden in the afternoon; and both Adam and his wife hid themselves from the face of the Lord God in the midst of the trees of the garden.
+10|And the Lord God called Adam and said to him, Adam, where art thou?
+11|And he said to him, I heard thy voice as thou walkedst in the garden, and I feared because I was naked and I hid myself.
+12|And God said to him, Who told thee that thou wast naked, unless thou hast eaten of the tree concerning which I charged thee of it alone not to eat?
+13|And Adam said, The woman whom thou gavest to be with me—she gave me of the tree and I ate.
+14|And the Lord God said to the woman, Why hast thou done this? And the woman said, The serpent deceived me and I ate.
+15|And the Lord God said to the serpent, Because thou hast done this thou art cursed above all cattle and all the brutes of the earth, on thy breast and belly thou shalt go, and thou shalt eat earth all the days of thy life.
+16|And I will put enmity between thee and the woman and between thy seed and her seed, he shall watch against thy head, and thou shalt watch against his heel.
+17|And to the woman he said, I will greatly multiply thy pains and thy groanings; in pain thou shalt bring forth children, and thy submission shall be to thy husband, and he shall rule over thee.
+18|And to Adam he said, Because thou hast hearkened to the voice of thy wife, and eaten of the tree concerning which I charged thee of it only not to eat—of that thou hast eaten, cursed <i>is</i> the ground in thy labours, in pain shalt thou eat of it all the days of thy life.
+19|Thorns and thistles shall it bring forth to thee, and thou shalt eat the herb of the field.
+20|In the sweat of thy face shalt thou eat thy bread until thou return to the earth out of which thou wast taken, for earth thou art and to earth thou shalt return.
+21|And Adam called the name of his wife Life, because she was the mother of all living.
+22|And the Lord God made for Adam and his wife garments of skin, and clothed them.
+23|And God said, Behold, Adam is become as one of us, to know good and evil, and now lest at any time he stretch forth his hand, and take of the tree of life and eat, and <i>so</i> he shall live forever—
+24|So the Lord God sent him forth out of the garden of Delight to cultivate the ground out of which he was taken.
+25|And he cast out Adam and caused him to dwell over against the garden of Delight, and stationed the cherubs and the fiery sword that turns about to keep the way of the tree of life.
 
 #4
-1| And Adam knew Eve his wife, and she conceived and brought forth Cain and said, I have gained a man through God. 
-2| And she again bore his brother Abel. And Abel was a keeper of sheep, but Cain was a tiller of the ground.
- 3| And it was so after some time that Cain brought of the fruits of the earth a sacrifice to the Lord. 
-4| And Abel also brought of the first born of his sheep and of his fatlings, and God looked upon Abel and his gifts, 
-5| but Cain and his sacrifices he regarded not, and Cain was exceedingly sorrowful and his countenance fell.
- 6| And the Lord God said to Cain, Why art thou become very sorrowful and why is thy countenance fallen? 
-7| Hast thou not sinned if thou hast brought it rightly, but not rightly divided it? be still, to thee shall be his submission, and thou shalt rule over him. 	
-8| And Cain said to Abel his brother, Let us go out into the plain; and it came to pass that when they were in the plain Cain rose up against Abel his brother, and slew him. 
-9| And the Lord God said to Cain, Where is Abel thy brother? and he said, I know not, am I my brother’s keeper? 
-10| And the Lord said, What hast thou done? the voice of thy brother’s blood cries to me out of the ground. 
-11| And now thou <i>art</i> cursed from the earth which has opened her mouth to receive thy brother’s blood from thy hand. 
-12| When thou tillest the earth, then it shall not continue to give its strength to thee: thou shalt be groaning and trembling on the earth.
- 13| And Cain said to the Lord God, My crime <i>is</i> too great for me to be forgiven. 
-14| If thou castest me out this day from the face of the earth, and I shall be hidden from thy presence, and I shall be groaning and trembling upon the earth, then it will be that any one that finds me shall slay me. 
-15| And the Lord God said to him, Not so, any one that slays Cain shall suffer seven-fold vengeance; and the Lord God set a mark upon Cain that no one that found him might slay him.
- 16| So Cain went forth from the presence of God and dwelt in the land of Nod over against Edem. 
-17| And Cain knew his wife, and having conceived she bore Enoch; and he built a city; and he named the city after the name of his son, Enoch. 
-18| And to Enoch was born Gaidad; and Gaidad begot Maleleel; and Maleleel begot Mathusala; and Mathusala begot Lamech.
- 19| And Lamech took to himself two wives; the name of the one was Ada, and the name of the second Sella. 
-20| And Ada bore Jobel; he was the father of those that dwell in tents, feeding cattle. 
-21| And the name of his brother was Jubal; he it was who invented the psaltery and harp. 
-22| And Sella also bore Thobel; he was a smith, a manufacturer both of brass and iron; and the sister of Thobel was Noema.
- 23| And Lamech said to his wives, Ada and Sella, Hear my voice, ye wives of Lamech, consider my words, because I have slain a man to my sorrow and a youth to my grief. 
-24| Because vengeance has been exacted seven times on Cain’s behalf, on Lamech’s <i>it shall be</i> seventy times seven. 	
-25| And Adam knew Eve his wife, and she conceived and bore a son, and called his name Seth, saying, For God has raised up to me another seed instead of Abel, whom Cain slew. 
-26| And Seth had a son, and he called his name Enos: he hoped to call on the name of the Lord God. 	 	
+1|And Adam knew Eve his wife, and she conceived and brought forth Cain and said, I have gained a man through God.
+2|And she again bore his brother Abel. And Abel was a keeper of sheep, but Cain was a tiller of the ground.
+3|And it was so after some time that Cain brought of the fruits of the earth a sacrifice to the Lord.
+4|And Abel also brought of the first born of his sheep and of his fatlings, and God looked upon Abel and his gifts,
+5|but Cain and his sacrifices he regarded not, and Cain was exceedingly sorrowful and his countenance fell.
+6|And the Lord God said to Cain, Why art thou become very sorrowful and why is thy countenance fallen?
+7|Hast thou not sinned if thou hast brought it rightly, but not rightly divided it? be still, to thee shall be his submission, and thou shalt rule over him.
+8|And Cain said to Abel his brother, Let us go out into the plain; and it came to pass that when they were in the plain Cain rose up against Abel his brother, and slew him.
+9|And the Lord God said to Cain, Where is Abel thy brother? and he said, I know not, am I my brother's keeper?
+10|And the Lord said, What hast thou done? the voice of thy brother's blood cries to me out of the ground.
+11|And now thou <i>art</i> cursed from the earth which has opened her mouth to receive thy brother's blood from thy hand.
+12|When thou tillest the earth, then it shall not continue to give its strength to thee: thou shalt be groaning and trembling on the earth.
+13|And Cain said to the Lord God, My crime <i>is</i> too great for me to be forgiven.
+14|If thou castest me out this day from the face of the earth, and I shall be hidden from thy presence, and I shall be groaning and trembling upon the earth, then it will be that any one that finds me shall slay me.
+15|And the Lord God said to him, Not so, any one that slays Cain shall suffer seven-fold vengeance; and the Lord God set a mark upon Cain that no one that found him might slay him.
+16|So Cain went forth from the presence of God and dwelt in the land of Nod over against Edem.
+17|And Cain knew his wife, and having conceived she bore Enoch; and he built a city; and he named the city after the name of his son, Enoch.
+18|And to Enoch was born Gaidad; and Gaidad begot Maleleel; and Maleleel begot Mathusala; and Mathusala begot Lamech.
+19|And Lamech took to himself two wives; the name of the one was Ada, and the name of the second Sella.
+20|And Ada bore Jobel; he was the father of those that dwell in tents, feeding cattle.
+21|And the name of his brother was Jubal; he it was who invented the psaltery and harp.
+22|And Sella also bore Thobel; he was a smith, a manufacturer both of brass and iron; and the sister of Thobel was Noema.
+23|And Lamech said to his wives, Ada and Sella, Hear my voice, ye wives of Lamech, consider my words, because I have slain a man to my sorrow and a youth to my grief.
+24|Because vengeance has been exacted seven times on Cain's behalf, on Lamech's <i>it shall be</i> seventy times seven.
+25|And Adam knew Eve his wife, and she conceived and bore a son, and called his name Seth, saying, For God has raised up to me another seed instead of Abel, whom Cain slew.
+26|And Seth had a son, and he called his name Enos: he hoped to call on the name of the Lord God.
 
 #5
-1| This <i>is</i> the genealogy of men in the day in which God made Adam; in the image of God he made him: 
-2| male and female he made them, and blessed them; and he called his name Adam, in the day in which he made them. 
-3| And Adam lived two hundred and thirty years, and begot <i>a son</i> after his <i>own</i> form, and after his <i>own</i> image, and he called his name Seth. 
-4| And the days of Adam, which he lived after his begetting Seth, were seven hundred years; and he begot sons and daughters. 
-5| And all the days of Adam which he lived were nine hundred and thirty years, and he died.
- 6| Now Seth lived two hundred and five years, and begot Enos. 
-7| And Seth lived after his begetting Enos, seven hundred and seven years, and he begot sons and daughters. 
-8| And all the days of Seth were nine hundred and twelve years, and he died. 
-9| And Enos lived an hundred and ninety years, and begot Cainan. 
-10| And Enos lived after his begetting Cainan, seven hundred and fifteen years, and he begot sons and daughters. 
-11| And all the days of Enos were nine hundred and five years, and he died. 
-12| And Cainan lived an hundred and seventy years, and he begot Maleleel. 
-13| And Cainan lived after his begetting Maleleel, seven hundred and forty years, and he begot sons and daughters. 
-14| And all the days of Cainan were nine hundred and ten years, and he died.  	
-15| And Maleleel lived an hundred and sixty and five years, and he begot Jared. 
-16| And Maleleel lived after his begetting Jared, seven hundred and thirty years, and he begot sons and daughters. 
-17| And all the days of Maleleel were eight hundred and ninety and five years, and he died. 
-18| And Jared lived an hundred and sixty and two years, and begot Enoch: 
-19| and Jared lived after his begetting Enoch, eight hundred years, and he begot sons and daughters. 
-20| And all the days of Jared were nine hundred and sixty and two years, and he died.
- 21| And Enoch lived an hundred and sixty and five years, and begat Mathusala. 
-22| And Enoch was well-pleasing to God after his begetting Mathusala, two hundred years, and he begot sons and daughters. 
-23| And all the days of Enoch were three hundred and sixty and five years. 
-24| And Enoch was well-pleasing to God, and was not found, because God translated him. 
-25| And Mathusala lived an hundred and sixty and seven years, and begot Lamech. 
-26| And Mathusala lived after his begetting Lamech eight hundred and two years, and begot sons and daughters. 
-27| And all the days of Mathusala which he lived, were nine hundred and sixty and nine years, and he died. 
-28| And Lamech lived an hundred and eighty and eight years, and begot a son. 
-29| And he called his name Noe, saying, This one will cause us to cease from our works, and from the toils of our hands, and from the earth, which the Lord God has cursed. 
-30| And Lamech lived after his begetting Noe, five hundred and sixty and five years, and begot sons and daughters. 
-31| And all the days of Lamech were seven hundred and fifty-three years, and he died.  	 	
+1|This <i>is</i> the genealogy of men in the day in which God made Adam; in the image of God he made him:
+2|male and female he made them, and blessed them; and he called his name Adam, in the day in which he made them.
+3|And Adam lived two hundred and thirty years, and begot <i>a son</i> after his <i>own</i> form, and after his <i>own</i> image, and he called his name Seth.
+4|And the days of Adam, which he lived after his begetting Seth, were seven hundred years; and he begot sons and daughters.
+5|And all the days of Adam which he lived were nine hundred and thirty years, and he died.
+6|Now Seth lived two hundred and five years, and begot Enos.
+7|And Seth lived after his begetting Enos, seven hundred and seven years, and he begot sons and daughters.
+8|And all the days of Seth were nine hundred and twelve years, and he died.
+9|And Enos lived an hundred and ninety years, and begot Cainan.
+10|And Enos lived after his begetting Cainan, seven hundred and fifteen years, and he begot sons and daughters.
+11|And all the days of Enos were nine hundred and five years, and he died.
+12|And Cainan lived an hundred and seventy years, and he begot Maleleel.
+13|And Cainan lived after his begetting Maleleel, seven hundred and forty years, and he begot sons and daughters.
+14|And all the days of Cainan were nine hundred and ten years, and he died.
+15|And Maleleel lived an hundred and sixty and five years, and he begot Jared.
+16|And Maleleel lived after his begetting Jared, seven hundred and thirty years, and he begot sons and daughters.
+17|And all the days of Maleleel were eight hundred and ninety and five years, and he died.
+18|And Jared lived an hundred and sixty and two years, and begot Enoch:
+19|and Jared lived after his begetting Enoch, eight hundred years, and he begot sons and daughters.
+20|And all the days of Jared were nine hundred and sixty and two years, and he died.
+21|And Enoch lived an hundred and sixty and five years, and begat Mathusala.
+22|And Enoch was well-pleasing to God after his begetting Mathusala, two hundred years, and he begot sons and daughters.
+23|And all the days of Enoch were three hundred and sixty and five years.
+24|And Enoch was well-pleasing to God, and was not found, because God translated him.
+25|And Mathusala lived an hundred and sixty and seven years, and begot Lamech.
+26|And Mathusala lived after his begetting Lamech eight hundred and two years, and begot sons and daughters.
+27|And all the days of Mathusala which he lived, were nine hundred and sixty and nine years, and he died.
+28|And Lamech lived an hundred and eighty and eight years, and begot a son.
+29|And he called his name Noe, saying, This one will cause us to cease from our works, and from the toils of our hands, and from the earth, which the Lord God has cursed.
+30|And Lamech lived after his begetting Noe, five hundred and sixty and five years, and begot sons and daughters.
+31|And all the days of Lamech were seven hundred and fifty-three years, and he died.
 
 #6
-1|  And Noe was five hundred years old, and he begot three sons, Sem, Cham, and Japheth. 	
-2| And it came to pass when men began to be numerous upon the earth, and daughters were born to them, 
-3| that the sons of God having seen the daughters of men that they were beautiful, took to themselves wives of all whom they chose.
- 4|  And the Lord God said, My Spirit shall certainly not remain among these men for ever, because they are flesh, but their days shall be an hundred and twenty years. 
-5| Now the giants were upon the earth in those days; and after that when the sons of God were wont to go in to the daughters of men, they bore <i>children</i> to them, those were the giants of old, the men of renown.  	
-6| And the Lord God, having seen that the wicked actions of men were multiplied upon the earth, and that every one in his heart was intently brooding over evil continually,
- 7|  then God laid it to heart that he had made man upon the earth, and he pondered <i>it</i> deeply. 
-8| And God said, I will blot out man whom I have made from the face of the earth, even man with cattle, and reptiles with flying creatures of the sky, for I am grieved that I have made them. 	
-9| But Noe found grace before the Lord God. 
-10|  And these <i>are</i> the generations of Noe. Noe was a just man; being perfect in his generation, Noe was well-pleasing to God. 
-11| And Noe begot three sons, Sem, Cham, Japheth.
- 12| But the earth was corrupted before God, and the earth was filled with iniquity. 
-13| And the Lord God saw the earth, and it was corrupted; because all flesh had corrupted its way upon the earth. 
-14| And the Lord God said to Noe, A period of all men is come before me; because the earth has been filled with iniquity by them, and, behold, I destroy them and the earth. 	
-15| Make therefore for thyself an ark of square timber; thou shalt make the ark in compartments, and thou shalt pitch it within and without with pitch. 
-16| And thus shalt thou make the ark; three hundred cubits the length of the ark, and fifty cubits the breadth, and thirty cubits the height of it. 
-17| Thou shalt narrow the ark in making it, and in a cubit above thou shalt finish it, and the door of the ark thou shalt make on the side; with lower, second, and third stories thou shalt make it. 
-18| And behold I bring a flood of water upon the earth, to destroy all flesh in which is the breath of life under heaven, and whatsoever things are upon the earth shall die. 	
-19| And I will establish my covenant with thee, and thou shalt enter into the ark, and thy sons and thy wife, and thy sons’ wives with thee. 
-20| And of all cattle and of all reptiles and of all wild beasts, even of all flesh, thou shalt bring by pairs of all, into the ark, that thou mayest feed them with thyself: male and female they shall be. 
-21| Of all winged birds after their kind, and of all cattle after their kind, and of all reptiles creeping upon the earth after their kind, pairs of all shall come in to thee, male and female to be fed with thee. 
-22| And thou shalt take to thyself of all kinds of food which ye eat, and thou shalt gather them to thyself, and it shall be for thee and them to eat.
- 23| &nbsp;And Noe did all things whatever the Lord God commanded him, so did he. 	 	
+1|And Noe was five hundred years old, and he begot three sons, Sem, Cham, and Japheth.
+2|And it came to pass when men began to be numerous upon the earth, and daughters were born to them,
+3|that the sons of God having seen the daughters of men that they were beautiful, took to themselves wives of all whom they chose.
+4|And the Lord God said, My Spirit shall certainly not remain among these men for ever, because they are flesh, but their days shall be an hundred and twenty years.
+5|Now the giants were upon the earth in those days; and after that when the sons of God were wont to go in to the daughters of men, they bore <i>children</i> to them, those were the giants of old, the men of renown.
+6|And the Lord God, having seen that the wicked actions of men were multiplied upon the earth, and that every one in his heart was intently brooding over evil continually,
+7|then God laid it to heart that he had made man upon the earth, and he pondered <i>it</i> deeply.
+8|And God said, I will blot out man whom I have made from the face of the earth, even man with cattle, and reptiles with flying creatures of the sky, for I am grieved that I have made them.
+9|But Noe found grace before the Lord God.
+10|And these <i>are</i> the generations of Noe. Noe was a just man; being perfect in his generation, Noe was well-pleasing to God.
+11|And Noe begot three sons, Sem, Cham, Japheth.
+12|But the earth was corrupted before God, and the earth was filled with iniquity.
+13|And the Lord God saw the earth, and it was corrupted; because all flesh had corrupted its way upon the earth.
+14|And the Lord God said to Noe, A period of all men is come before me; because the earth has been filled with iniquity by them, and, behold, I destroy them and the earth.
+15|Make therefore for thyself an ark of square timber; thou shalt make the ark in compartments, and thou shalt pitch it within and without with pitch.
+16|And thus shalt thou make the ark; three hundred cubits the length of the ark, and fifty cubits the breadth, and thirty cubits the height of it.
+17|Thou shalt narrow the ark in making it, and in a cubit above thou shalt finish it, and the door of the ark thou shalt make on the side; with lower, second, and third stories thou shalt make it.
+18|And behold I bring a flood of water upon the earth, to destroy all flesh in which is the breath of life under heaven, and whatsoever things are upon the earth shall die.
+19|And I will establish my covenant with thee, and thou shalt enter into the ark, and thy sons and thy wife, and thy sons' wives with thee.
+20|And of all cattle and of all reptiles and of all wild beasts, even of all flesh, thou shalt bring by pairs of all, into the ark, that thou mayest feed them with thyself: male and female they shall be.
+21|Of all winged birds after their kind, and of all cattle after their kind, and of all reptiles creeping upon the earth after their kind, pairs of all shall come in to thee, male and female to be fed with thee.
+22|And thou shalt take to thyself of all kinds of food which ye eat, and thou shalt gather them to thyself, and it shall be for thee and them to eat.
+23|&nbsp;And Noe did all things whatever the Lord God commanded him, so did he.
 
 #7
-1| And the Lord God said to Noe, Enter thou and all thy family into the ark, for thee have I seen righteous before me in this generation. 
-2| And of the clean cattle take in to thee sevens, male and female, and of the unclean cattle pairs male and female. 
-3| And of clean flying creatures of the sky sevens, male and female, and of all unclean flying creatures pairs, male and female, to maintain seed on all the earth. 
-4| For yet seven days <i>having passed</i> I bring rain upon the earth forty days and forty nights, and I will blot out every offspring which I have made from the face of all the earth. 
-5| And Noe <i>did</i> all things whatever the Lord God commanded him. 
-6| And Noe was six hundred years old when the flood of water was upon the earth. 
-7| And then went in Noe and his sons and his wife, and his sons’ wives with him into the ark, because of the water of the flood. 
-8| And of clean flying creatures and of unclean flying creatures, and of clean cattle and of unclean cattle, and of all things that creep upon the earth, 
-9| pairs went in to Noe into the ark, male and female, as God commanded Noe. 
-10| And it came to pass after the seven days that the water of the flood came upon the earth.
- 11| In the six hundredth year of the life of Noe, in the second month, on the twenty-seventh day of the month, on this day all the fountains of the abyss were broken up, and the flood-gates of heaven were opened. 
-12| And the rain was upon the earth forty days and forty nights.
- 13| On that very day entered Noe, Sem, Cham, Japheth, the sons of Noe, and the wife of Noe, and the three wives of his sons with him into the ark. 
-14| And all the wild beasts after their kind, and all cattle after their kind, and every reptile moving itself on the earth after its kind, and every flying bird after its kind, 
-15| went in to Noe into the ark, pairs, male and female of all flesh in which is the breath of life. 
-16| And they that entered went in male and female of all flesh, as God commanded Noe, and the Lord God shut the ark outside of him. 	
-17| And the flood was upon the earth forty days and forty nights, and the water abounded greatly and bore up the ark, and it was lifted on high from off the earth. 
-18| And the water prevailed and abounded exceedingly upon the earth, and the ark was borne upon the water. 
-19| And the water prevailed exceedingly upon the earth, and covered all the high mountains which were under heaven. 
-20| Fifteen cubits upwards was the water raised, and it covered all the high mountains. 
-21| And there died all flesh that moved upon the earth, of flying creatures and cattle, and of wild beasts, and every reptile moving upon the earth, and every man. 
-22| And all things which have the breath of life, and whatever was on the dry land, died. 
-23| And <i>God</i> blotted out every offspring which was upon the face of the earth, both man and beast, and reptiles, and birds of the sky, and they were blotted out from the earth, and Noe was left alone, and those with him in the ark. 
-24| And the water was raised over the earth an hundred and fifty days. 	 	
+1|And the Lord God said to Noe, Enter thou and all thy family into the ark, for thee have I seen righteous before me in this generation.
+2|And of the clean cattle take in to thee sevens, male and female, and of the unclean cattle pairs male and female.
+3|And of clean flying creatures of the sky sevens, male and female, and of all unclean flying creatures pairs, male and female, to maintain seed on all the earth.
+4|For yet seven days <i>having passed</i> I bring rain upon the earth forty days and forty nights, and I will blot out every offspring which I have made from the face of all the earth.
+5|And Noe <i>did</i> all things whatever the Lord God commanded him.
+6|And Noe was six hundred years old when the flood of water was upon the earth.
+7|And then went in Noe and his sons and his wife, and his sons' wives with him into the ark, because of the water of the flood.
+8|And of clean flying creatures and of unclean flying creatures, and of clean cattle and of unclean cattle, and of all things that creep upon the earth,
+9|pairs went in to Noe into the ark, male and female, as God commanded Noe.
+10|And it came to pass after the seven days that the water of the flood came upon the earth.
+11|In the six hundredth year of the life of Noe, in the second month, on the twenty-seventh day of the month, on this day all the fountains of the abyss were broken up, and the flood-gates of heaven were opened.
+12|And the rain was upon the earth forty days and forty nights.
+13|On that very day entered Noe, Sem, Cham, Japheth, the sons of Noe, and the wife of Noe, and the three wives of his sons with him into the ark.
+14|And all the wild beasts after their kind, and all cattle after their kind, and every reptile moving itself on the earth after its kind, and every flying bird after its kind,
+15|went in to Noe into the ark, pairs, male and female of all flesh in which is the breath of life.
+16|And they that entered went in male and female of all flesh, as God commanded Noe, and the Lord God shut the ark outside of him.
+17|And the flood was upon the earth forty days and forty nights, and the water abounded greatly and bore up the ark, and it was lifted on high from off the earth.
+18|And the water prevailed and abounded exceedingly upon the earth, and the ark was borne upon the water.
+19|And the water prevailed exceedingly upon the earth, and covered all the high mountains which were under heaven.
+20|Fifteen cubits upwards was the water raised, and it covered all the high mountains.
+21|And there died all flesh that moved upon the earth, of flying creatures and cattle, and of wild beasts, and every reptile moving upon the earth, and every man.
+22|And all things which have the breath of life, and whatever was on the dry land, died.
+23|And <i>God</i> blotted out every offspring which was upon the face of the earth, both man and beast, and reptiles, and birds of the sky, and they were blotted out from the earth, and Noe was left alone, and those with him in the ark.
+24|And the water was raised over the earth an hundred and fifty days.
 
 #8
-1| And God remembered Noe, and all the wild beasts, and all the cattle, and all the birds, and all the reptiles that creep, as many as were with him in the ark, and God brought a wind upon the earth, and the water stayed. 
-2| And the fountains of the deep were closed up, and the flood-gates of heaven, and the rain from heaven was withheld. 
-3| And the water subsided, and went off the earth, and after an hundred and fifty days the water was diminished, and the ark rested in the seventh month, on the twenty-seventh day of the month, on the mountains of Ararat. 
-4| And the water continued to decrease until the tenth month. 
-5| And in the tenth month, on the first day of the month, the heads of the mountains were seen. 
-6| And it came to pass after forty days Noe opened the window of the ark which he had made. 
-7| And he sent forth a raven; and it went forth and returned not until the water was dried from off the earth. 
-8| And he sent a dove after it to see if the water had ceased from off the earth. 
-9| And the dove not having found rest for her feet, returned to him into the ark, because the water was on all the face of the earth, and he stretched out his hand and took her, and brought her to himself into the ark. 
-10| And having waited yet seven other days, he again sent forth the dove from the ark. 
-11| And the dove returned to him in the evening, and had a leaf of olive, a sprig in her mouth; and Noe knew that the water had ceased from off the earth. 
-12| And having waited yet seven other days, he again sent forth the dove, and she did not return to him again any more. 
-13| And it came to pass in the six hundred and first year of the life of Noe, in the first month, on the first day of the month, the water subsided from off the earth, and Noe opened the covering of the ark which he had made, and he saw that the water had subsided from the face of the earth. 
-14| And in the second month the earth was dried, on the twenty-seventh day of the month. 	
-15| And the Lord God spoke to Noe, saying, 
-16| Come out from the ark, thou and thy wife and thy sons, and thy sons’ wives with thee. 
-17| And all the wild beasts as many as are with thee, and all flesh both of birds and beasts, and every reptile moving upon the earth, bring forth with thee: and increase ye and multiply upon the earth. 
-18| And Noe came forth, and his wife and his sons, and his sons’ wives with him. 
-19| And all the wild beasts and all the cattle and every bird, and every reptile creeping upon the earth after their kind, came forth out of the ark. 	
-20| And Noe built an altar to the Lord, and took of all clean beasts, and of all clean birds, and offered a whole burnt-offering upon the altar. 
-21| And the Lord God smelled a smell of sweetness, and the Lord God having considered, said, I will not any more curse the earth, because of the works of men, because the imagination of man is intently bent upon evil things from his youth, I will not therefore any more smite all living flesh as I have done. 
-22| All the days of the earth, seed and harvest, cold and heat, summer and spring, shall not cease by day or night. 	 	
+1|And God remembered Noe, and all the wild beasts, and all the cattle, and all the birds, and all the reptiles that creep, as many as were with him in the ark, and God brought a wind upon the earth, and the water stayed.
+2|And the fountains of the deep were closed up, and the flood-gates of heaven, and the rain from heaven was withheld.
+3|And the water subsided, and went off the earth, and after an hundred and fifty days the water was diminished, and the ark rested in the seventh month, on the twenty-seventh day of the month, on the mountains of Ararat.
+4|And the water continued to decrease until the tenth month.
+5|And in the tenth month, on the first day of the month, the heads of the mountains were seen.
+6|And it came to pass after forty days Noe opened the window of the ark which he had made.
+7|And he sent forth a raven; and it went forth and returned not until the water was dried from off the earth.
+8|And he sent a dove after it to see if the water had ceased from off the earth.
+9|And the dove not having found rest for her feet, returned to him into the ark, because the water was on all the face of the earth, and he stretched out his hand and took her, and brought her to himself into the ark.
+10|And having waited yet seven other days, he again sent forth the dove from the ark.
+11|And the dove returned to him in the evening, and had a leaf of olive, a sprig in her mouth; and Noe knew that the water had ceased from off the earth.
+12|And having waited yet seven other days, he again sent forth the dove, and she did not return to him again any more.
+13|And it came to pass in the six hundred and first year of the life of Noe, in the first month, on the first day of the month, the water subsided from off the earth, and Noe opened the covering of the ark which he had made, and he saw that the water had subsided from the face of the earth.
+14|And in the second month the earth was dried, on the twenty-seventh day of the month.
+15|And the Lord God spoke to Noe, saying,
+16|Come out from the ark, thou and thy wife and thy sons, and thy sons' wives with thee.
+17|And all the wild beasts as many as are with thee, and all flesh both of birds and beasts, and every reptile moving upon the earth, bring forth with thee: and increase ye and multiply upon the earth.
+18|And Noe came forth, and his wife and his sons, and his sons' wives with him.
+19|And all the wild beasts and all the cattle and every bird, and every reptile creeping upon the earth after their kind, came forth out of the ark.
+20|And Noe built an altar to the Lord, and took of all clean beasts, and of all clean birds, and offered a whole burnt-offering upon the altar.
+21|And the Lord God smelled a smell of sweetness, and the Lord God having considered, said, I will not any more curse the earth, because of the works of men, because the imagination of man is intently bent upon evil things from his youth, I will not therefore any more smite all living flesh as I have done.
+22|All the days of the earth, seed and harvest, cold and heat, summer and spring, shall not cease by day or night.
 
 #9
-1| And God blessed Noe and his sons, and said to them, Increase and multiply, and fill the earth and have dominion over it. 
-2| And the dread and the fear of you shall be upon all the wild beasts of the earth, on all the birds of the sky, and on all things moving upon the earth, and upon all the fishes of the sea, I have placed them under you power. 
-3| And every reptile which is living shall be to you for meat, I have given all things to you as the green herbs. 
-4| But flesh with blood of life ye shall not eat. 
-5| For your blood of your lives will I require at the hand of all wild beasts, and I will require the life of man at the hand of <i>his</i> brother man. 
-6| He that sheds man’s blood, instead of that blood shall his own be shed, for in the image of God I made man. 
-7| But do ye increase and multiply, and fill the earth, and have dominion over it. 	
-8| And God spoke to Noe, and to his sons with him, saying, 
-9| And behold I establish my covenant with you, and with your seed after you, 
-10| and with every living creature with you, of birds and of beasts, and with all the wild beasts of the earth, as many as are with you, of all that come out of the ark. 
-11| And I will establish my covenant with you and all flesh shall not any more die by the water of the flood, and there shall no more be a flood of water to destroy all the earth. 
-12| And the Lord God said to Noe, This <i>is</i> the sign of the covenant which I set between me and you, and between every living creature which is with you for perpetual generations. 
-13| I set my bow in the cloud, and it shall be for a sign of covenant between me and the earth. 
-14| And it shall be when I gather clouds upon the earth, that my bow shall be seen in the cloud. 
-15| And I will remember my covenant, which is between me and you, and between every living soul in all flesh, and there shall no longer be water for a deluge, so as to blot out all flesh. 
-16| And my bow shall be in the cloud, and I will look to remember the everlasting covenant between me and the earth, and between <i>every</i> living soul in all flesh, which is upon the earth. 
-17| And God said to Noe, This <i>is</i> the sign of the covenant, which I have made between me and all flesh, which is upon the earth. 	
-18| Now the sons of Noe which came out of the ark, were Sem, Cham, Japheth. And Cham was father of Chanaan. 
-19| These three are the sons of Noe, of these were men scattered over all the earth. 
-20| And Noe began to be a husbandman, and he planted a vineyard. 
-21| And he drank of the wine, and was drunk, and was naked in his house. 
-22| And Cham the father of Chanaan saw the nakedness of his father, and he went out and told his two brothers without. 
-23| And Sem and Japheth having taken a garment, put it on both their backs and went backwards, and covered the nakedness of their father; and their face <i>was</i> backward, and they saw not the nakedness of their father. 
-24| And Noe recovered from the wine, and knew all that his younger son had done to him. 
-25| And he said, Cursed be the servant Chanaan, a slave shall he be to his brethren. 
-26| And he said, Blessed <i>be</i> the Lord God of Sem, and Chanaan shall be his bond-servant. 
-27| May God make room for Japheth, and let him dwell in the habitations of Sem, and let Chanaan be his servant. 	
-28| And Noe lived after the flood three hundred and fifty years. 
-29| And all the days of Noe were nine hundred and fifty years, and he died. 	0 	
+1|And God blessed Noe and his sons, and said to them, Increase and multiply, and fill the earth and have dominion over it.
+2|And the dread and the fear of you shall be upon all the wild beasts of the earth, on all the birds of the sky, and on all things moving upon the earth, and upon all the fishes of the sea, I have placed them under you power.
+3|And every reptile which is living shall be to you for meat, I have given all things to you as the green herbs.
+4|But flesh with blood of life ye shall not eat.
+5|For your blood of your lives will I require at the hand of all wild beasts, and I will require the life of man at the hand of <i>his</i> brother man.
+6|He that sheds man's blood, instead of that blood shall his own be shed, for in the image of God I made man.
+7|But do ye increase and multiply, and fill the earth, and have dominion over it.
+8|And God spoke to Noe, and to his sons with him, saying,
+9|And behold I establish my covenant with you, and with your seed after you,
+10|and with every living creature with you, of birds and of beasts, and with all the wild beasts of the earth, as many as are with you, of all that come out of the ark.
+11|And I will establish my covenant with you and all flesh shall not any more die by the water of the flood, and there shall no more be a flood of water to destroy all the earth.
+12|And the Lord God said to Noe, This <i>is</i> the sign of the covenant which I set between me and you, and between every living creature which is with you for perpetual generations.
+13|I set my bow in the cloud, and it shall be for a sign of covenant between me and the earth.
+14|And it shall be when I gather clouds upon the earth, that my bow shall be seen in the cloud.
+15|And I will remember my covenant, which is between me and you, and between every living soul in all flesh, and there shall no longer be water for a deluge, so as to blot out all flesh.
+16|And my bow shall be in the cloud, and I will look to remember the everlasting covenant between me and the earth, and between <i>every</i> living soul in all flesh, which is upon the earth.
+17|And God said to Noe, This <i>is</i> the sign of the covenant, which I have made between me and all flesh, which is upon the earth.
+18|Now the sons of Noe which came out of the ark, were Sem, Cham, Japheth. And Cham was father of Chanaan.
+19|These three are the sons of Noe, of these were men scattered over all the earth.
+20|And Noe began to be a husbandman, and he planted a vineyard.
+21|And he drank of the wine, and was drunk, and was naked in his house.
+22|And Cham the father of Chanaan saw the nakedness of his father, and he went out and told his two brothers without.
+23|And Sem and Japheth having taken a garment, put it on both their backs and went backwards, and covered the nakedness of their father; and their face <i>was</i> backward, and they saw not the nakedness of their father.
+24|And Noe recovered from the wine, and knew all that his younger son had done to him.
+25|And he said, Cursed be the servant Chanaan, a slave shall he be to his brethren.
+26|And he said, Blessed <i>be</i> the Lord God of Sem, and Chanaan shall be his bond-servant.
+27|May God make room for Japheth, and let him dwell in the habitations of Sem, and let Chanaan be his servant.
+28|And Noe lived after the flood three hundred and fifty years.
+29|And all the days of Noe were nine hundred and fifty years, and he died.
 
 #10
-1| Now these <i>are</i> the generations of the sons of Noe, Sem, Cham, Japheth; and sons were born to them after the flood.  	
-2| The sons of Japheth, Gamer, and Magog, and Madoi, and Jovan, and Elisa, and Thobel, and Mosoch, and Thiras. 
-3| And the sons of Gamer, Aschanaz, and Riphath, and Thorgama. 
-4| And the sons of Jovan, Elisa, and Tharseis, Cetians, Rhodians. 
-5| From these were the islands of the Gentiles divided in their land, each according to his tongue, in their tribes and in their nations. 	
-6| And the sons of Cham, Chus, and Mesrain, Phud, and Chanaan. 
-7| And the sons of Chus, Saba, and Evila, and Sabatha, and Rhegma, and Sabathaca. And the sons of Rhegma, Saba, and Dadan. 
-8| And Chus begot Nebrod: he began to be a giant upon the earth. 
-9| He was a giant hunter before the Lord God; therefore they say, As Nebrod the giant hunter before the Lord. 
-10| And the beginning of his kingdom was Babylon, and Orech, and Archad, and Chalanne, in the land of Senaar. 
-11| Out of that land came Assur, and built Ninevi, and the city Rhooboth, and Chalach, 
-12| and Dase between Ninevi and Chalach: this is the great city. 
-13| And Mesrain begot the Ludiim, and the Nephthalim, and the Enemetiim, and the Labiim, 
-14| and the Patrosoniim, and the Chasmoniim (whence came forth Phylistiim) and the Gaphthoriim. 
-15| And Chanaan begot Sidon his first-born, and the Chettite, 
-16| and the Jebusite, and the Amorite, and the Girgashite, 
-17| and the Evite, and the Arukite, and the Asennite, 
-18| and the Aradian, and the Samarean, and the Amathite; and after this the tribes of the Chananites were dispersed. 
-19| And the boundaries of the Chananites were from Sidon till one comes to Gerara and Gaza, till one comes to Sodom and Gomorrha, Adama and Seboim, as far as Dasa. 
-20| There <i>were</i> the sons of Cham in their tribes according to their tongues, in their countries, and in their nations. 	
-21| And to Sem himself also were children born, the father of all the sons of Heber, the brother of Japheth the elder. 
-22| Sons of Sem, Elam, and Assur, and Arphaxad, and Lud, and Aram, and Cainan. 
-23| And sons of Aram, Uz, and Ul, and Gater, and Mosoch. 
-24| And Arphaxad begot Cainan, and Cainan begot Sala. And Sala begot Heber. 
-25| And to Heber were born two sons, the name of the one, Phaleg, because in his days the earth was divided, and the name of his brother Jektan. 
-26| And Jektan begot Elmodad, and Saleth, and Sarmoth, and Jarach, 
-27| and Odorrha, and Aibel, and Decla, 
-28| Eval, and Abimael, and Saba, 
-29| and Uphir, and Evila, and Jobab, all these were the sons of Jektan. 
-30| And their dwelling was from Masse, till one comes to Saphera, a mountain of the east. 
-31| These were the sons of Sem in their tribes, according to their tongues, in their countries, and in their nations. 
-32| These are the tribes of the sons of Noe, according to their generations, according to their nations: of them were the islands of the Gentiles scattered over the earth after the flood. 	1 	
+1|Now these <i>are</i> the generations of the sons of Noe, Sem, Cham, Japheth; and sons were born to them after the flood.
+2|The sons of Japheth, Gamer, and Magog, and Madoi, and Jovan, and Elisa, and Thobel, and Mosoch, and Thiras.
+3|And the sons of Gamer, Aschanaz, and Riphath, and Thorgama.
+4|And the sons of Jovan, Elisa, and Tharseis, Cetians, Rhodians.
+5|From these were the islands of the Gentiles divided in their land, each according to his tongue, in their tribes and in their nations.
+6|And the sons of Cham, Chus, and Mesrain, Phud, and Chanaan.
+7|And the sons of Chus, Saba, and Evila, and Sabatha, and Rhegma, and Sabathaca. And the sons of Rhegma, Saba, and Dadan.
+8|And Chus begot Nebrod: he began to be a giant upon the earth.
+9|He was a giant hunter before the Lord God; therefore they say, As Nebrod the giant hunter before the Lord.
+10|And the beginning of his kingdom was Babylon, and Orech, and Archad, and Chalanne, in the land of Senaar.
+11|Out of that land came Assur, and built Ninevi, and the city Rhooboth, and Chalach,
+12|and Dase between Ninevi and Chalach: this is the great city.
+13|And Mesrain begot the Ludiim, and the Nephthalim, and the Enemetiim, and the Labiim,
+14|and the Patrosoniim, and the Chasmoniim (whence came forth Phylistiim) and the Gaphthoriim.
+15|And Chanaan begot Sidon his first-born, and the Chettite,
+16|and the Jebusite, and the Amorite, and the Girgashite,
+17|and the Evite, and the Arukite, and the Asennite,
+18|and the Aradian, and the Samarean, and the Amathite; and after this the tribes of the Chananites were dispersed.
+19|And the boundaries of the Chananites were from Sidon till one comes to Gerara and Gaza, till one comes to Sodom and Gomorrha, Adama and Seboim, as far as Dasa.
+20|There <i>were</i> the sons of Cham in their tribes according to their tongues, in their countries, and in their nations.
+21|And to Sem himself also were children born, the father of all the sons of Heber, the brother of Japheth the elder.
+22|Sons of Sem, Elam, and Assur, and Arphaxad, and Lud, and Aram, and Cainan.
+23|And sons of Aram, Uz, and Ul, and Gater, and Mosoch.
+24|And Arphaxad begot Cainan, and Cainan begot Sala. And Sala begot Heber.
+25|And to Heber were born two sons, the name of the one, Phaleg, because in his days the earth was divided, and the name of his brother Jektan.
+26|And Jektan begot Elmodad, and Saleth, and Sarmoth, and Jarach,
+27|and Odorrha, and Aibel, and Decla,
+28|Eval, and Abimael, and Saba,
+29|and Uphir, and Evila, and Jobab, all these were the sons of Jektan.
+30|And their dwelling was from Masse, till one comes to Saphera, a mountain of the east.
+31|These were the sons of Sem in their tribes, according to their tongues, in their countries, and in their nations.
+32|These are the tribes of the sons of Noe, according to their generations, according to their nations: of them were the islands of the Gentiles scattered over the earth after the flood.
 
 #11
-1| And all the earth was one lip, and there was one language to all. 
-2| And it came to pass as they moved from the east, they found a plain in the land of Senaar, and they dwelt there. 
-3| And a man said to his neighbour, Come, let us make bricks and bake them with fire. And the brick was to them for stone, and their mortar was bitumen. 
-4| And they said, Come, let us build to ourselves a city and tower, whose top shall be to heaven, and let us make to ourselves a name, before we are scattered abroad upon the face of all the earth. 
-5| And the Lord came down to see the city and the tower, which the sons of men built. 
-6| And the Lord said, Behold, <i>there is</i> one race, and one lip of all, and they have begun to do this, and now nothing shall fail from them of all that they may have undertaken to do. 
-7| Come, and having gone down let us there confound their tongue, that they may not understand each the voice of his neighbour. 
-8| And the Lord scattered them thence over the face of all the earth, and they left off building the city and the tower. 
-9| On this account its name was called Confusion, because there the Lord confounded the languages of all the earth, and thence the Lord scattered them upon the face of all the earth. 	
-10| And these <i>are</i> the generations of Sem: and Sem was a hundred years old when he begot Arphaxad, the second year after the flood. 
-11| And Sem lived, after he had begotten Arphaxad, five hundred years, and begot sons and daughters, and died. 
-12| And Arphaxad lived a hundred and thirty-five years, and begot Cainan. 
-13| And Arphaxad lived after he had begotten Cainan, four hundred years, and begot sons and daughters, and died. And Cainan lived a hundred and thirty years and begot Sala; and Canaan lived after he had begotten Sala, three hundred and thirty years, and begot sons and daughters, and died. 
-14| And Sala lived an hundred and thirty years, and begot Heber. 
-15| And Sala lived after he had begotten Heber, three hundred and thirty years, and begot sons and daughters, and died. 
-16| And Heber lived an hundred and thirty-four years, and begot Phaleg. 
-17| And Heber lived after he had begotten Phaleg two hundred and seventy years, and begot sons and daughters, and died. 
-18| And Phaleg lived and hundred and thirty years, and begot Ragau. 
-19| And Phaleg lived after he had begotten Ragau, two hundred and nine years, and begot sons and daughters, and died. 
-20| And Ragau lived and hundred thirty and two years, and begot Seruch. 
-21| And Raau lived after he had begotten Seruch, two hundred and seven years, and begot sons and daughters, and died. 
-22| And Seruch lived a hundred and thirty years, and begot Nachor. 
-23| And Seruch lived after he had begotten Nachor, two hundred years, and begot sons and daughters, and died. 
-24| And Nachor lived a hundred and seventy-nine years, and begot Tharrha. 
-25| And Nachor lived after he had begotten Tharrha, an hundred and twenty-five years, and begot sons and daughters, and he died. 
-26| And Tharrha lived seventy years, and begot Abram, and Nachor, and Arrhan. 	
-27| And these <i>are</i> the generations of Tharrha. Tharrha begot Abram and Nachor, and Arrhan; and Arrhan begot Lot. 
-28| And Arrhan died in the presence of Tharrha his father, in the land in which he was born, in the country of the Chaldees. 
-29| And Abram and Nachor took to themselves wives, the name of the wife of Abram was Sara, and the name of the wife of Nachor, Malcha, daughter of Arrhan, and he was the father of Malcha, the father of Jescha. 
-30| And Sara was barren, and did not bear children. 
-31| And Tharrha took Abram his son, and Lot the son Arrhan, the son of his son, and Sara his daughter-in-law, the wife of Abram his son, and led them forth out of the land of the Chaldees, to go into the land of Chanaan, and they came as far as Charrhan, and he dwelt there. 
-32| And all the days of Tharrha in the land of Charrhan were two hundred and five years, and Tharrha died in Charrhan. 	2 	
+1|And all the earth was one lip, and there was one language to all.
+2|And it came to pass as they moved from the east, they found a plain in the land of Senaar, and they dwelt there.
+3|And a man said to his neighbour, Come, let us make bricks and bake them with fire. And the brick was to them for stone, and their mortar was bitumen.
+4|And they said, Come, let us build to ourselves a city and tower, whose top shall be to heaven, and let us make to ourselves a name, before we are scattered abroad upon the face of all the earth.
+5|And the Lord came down to see the city and the tower, which the sons of men built.
+6|And the Lord said, Behold, <i>there is</i> one race, and one lip of all, and they have begun to do this, and now nothing shall fail from them of all that they may have undertaken to do.
+7|Come, and having gone down let us there confound their tongue, that they may not understand each the voice of his neighbour.
+8|And the Lord scattered them thence over the face of all the earth, and they left off building the city and the tower.
+9|On this account its name was called Confusion, because there the Lord confounded the languages of all the earth, and thence the Lord scattered them upon the face of all the earth.
+10|And these <i>are</i> the generations of Sem: and Sem was a hundred years old when he begot Arphaxad, the second year after the flood.
+11|And Sem lived, after he had begotten Arphaxad, five hundred years, and begot sons and daughters, and died.
+12|And Arphaxad lived a hundred and thirty-five years, and begot Cainan.
+13|And Arphaxad lived after he had begotten Cainan, four hundred years, and begot sons and daughters, and died. And Cainan lived a hundred and thirty years and begot Sala; and Canaan lived after he had begotten Sala, three hundred and thirty years, and begot sons and daughters, and died.
+14|And Sala lived an hundred and thirty years, and begot Heber.
+15|And Sala lived after he had begotten Heber, three hundred and thirty years, and begot sons and daughters, and died.
+16|And Heber lived an hundred and thirty-four years, and begot Phaleg.
+17|And Heber lived after he had begotten Phaleg two hundred and seventy years, and begot sons and daughters, and died.
+18|And Phaleg lived and hundred and thirty years, and begot Ragau.
+19|And Phaleg lived after he had begotten Ragau, two hundred and nine years, and begot sons and daughters, and died.
+20|And Ragau lived and hundred thirty and two years, and begot Seruch.
+21|And Raau lived after he had begotten Seruch, two hundred and seven years, and begot sons and daughters, and died.
+22|And Seruch lived a hundred and thirty years, and begot Nachor.
+23|And Seruch lived after he had begotten Nachor, two hundred years, and begot sons and daughters, and died.
+24|And Nachor lived a hundred and seventy-nine years, and begot Tharrha.
+25|And Nachor lived after he had begotten Tharrha, an hundred and twenty-five years, and begot sons and daughters, and he died.
+26|And Tharrha lived seventy years, and begot Abram, and Nachor, and Arrhan.
+27|And these <i>are</i> the generations of Tharrha. Tharrha begot Abram and Nachor, and Arrhan; and Arrhan begot Lot.
+28|And Arrhan died in the presence of Tharrha his father, in the land in which he was born, in the country of the Chaldees.
+29|And Abram and Nachor took to themselves wives, the name of the wife of Abram was Sara, and the name of the wife of Nachor, Malcha, daughter of Arrhan, and he was the father of Malcha, the father of Jescha.
+30|And Sara was barren, and did not bear children.
+31|And Tharrha took Abram his son, and Lot the son Arrhan, the son of his son, and Sara his daughter-in-law, the wife of Abram his son, and led them forth out of the land of the Chaldees, to go into the land of Chanaan, and they came as far as Charrhan, and he dwelt there.
+32|And all the days of Tharrha in the land of Charrhan were two hundred and five years, and Tharrha died in Charrhan.
 
 #12
-1| And the Lord said to Abram, Go forth out of thy land and out of thy kindred, and out of the house of thy father, and come into the land which I will shew thee. 
-2| And I will make thee a great nation, and I will bless thee and magnify thy name, and thou shalt be blessed. 
-3| And I will bless those that bless thee, and curse those that curse thee, and in thee shall all the tribes of the earth be blessed. 
-4| And Abram went as the Lord spoke to him, and Lot departed with him, and Abram was seventy-five years old, when he went out of Charrhan. 
-5| And Abram took Sara his wife, and Lot the son of his brother, and all their possessions, as many as they had got, and every soul which they had got in Charrhan, and they went forth to go into the land of Chanaan. 
-6| And Abram traversed the land lengthwise as far as the place Sychem, to the high oak, and the Chananites then inhabited the land. 
-7| And the Lord appeared to Abram, and said to him, I will give this land to thy seed. And Abram built an altar there to the Lord who appeared to him. 
-8| And he departed thence to the mountain eastward of Baethel, and there he pitched his tent in Baethel near the sea, and Aggai toward the east, and there he built an altar to the Lord, and called on the name of the Lord. 
-9| And Abram departed and went and encamped in the wilderness. 	
-10| And there was a famine in the land, and Abram went down to Egypt to sojourn there, because the famine prevailed in the land. 
-11| And it came to pass when Abram drew nigh to enter into Egypt, Abram said to Sara his wife, I know that thou art a fair woman. 
-12| It shall come to pass then that when the Egyptians shall see thee, they shall say, This is his wife, and they shall slay me, but they shall save thee alive. 
-13| Say, therefore, I am his sister, that it may be well with me on account of thee, and my soul shall live because of thee. 
-14| And it came to pass when Abram entered into Egypt—the Egyptians having seen his wife that she was very beautiful— 
-15| that the princes of Pharao saw her, and praised her to Pharao and brought her into the house of Pharao. 
-16| And they treated Abram well on her account, and he had sheep, and calves, and asses, and men-servants, and women-servants, and mules, and camels. 
-17| And God afflicted Pharao with great and severe afflictions, and his house, because of Sara, Abram’s wife. 
-18| And Pharao having called Abram, said, What is this thou hast done to me, that thou didst not tell me that she was thy wife? 
-19| Wherefore didst thou say, She is my sister? and I took her for a wife to myself; and now, behold, thy wife is before thee, take her and go quickly away. 
-20| And Pharao gave charge to men concerning Abram, to join in sending him forward, and his wife, and all that he had. 	3 	
+1|And the Lord said to Abram, Go forth out of thy land and out of thy kindred, and out of the house of thy father, and come into the land which I will shew thee.
+2|And I will make thee a great nation, and I will bless thee and magnify thy name, and thou shalt be blessed.
+3|And I will bless those that bless thee, and curse those that curse thee, and in thee shall all the tribes of the earth be blessed.
+4|And Abram went as the Lord spoke to him, and Lot departed with him, and Abram was seventy-five years old, when he went out of Charrhan.
+5|And Abram took Sara his wife, and Lot the son of his brother, and all their possessions, as many as they had got, and every soul which they had got in Charrhan, and they went forth to go into the land of Chanaan.
+6|And Abram traversed the land lengthwise as far as the place Sychem, to the high oak, and the Chananites then inhabited the land.
+7|And the Lord appeared to Abram, and said to him, I will give this land to thy seed. And Abram built an altar there to the Lord who appeared to him.
+8|And he departed thence to the mountain eastward of Baethel, and there he pitched his tent in Baethel near the sea, and Aggai toward the east, and there he built an altar to the Lord, and called on the name of the Lord.
+9|And Abram departed and went and encamped in the wilderness.
+10|And there was a famine in the land, and Abram went down to Egypt to sojourn there, because the famine prevailed in the land.
+11|And it came to pass when Abram drew nigh to enter into Egypt, Abram said to Sara his wife, I know that thou art a fair woman.
+12|It shall come to pass then that when the Egyptians shall see thee, they shall say, This is his wife, and they shall slay me, but they shall save thee alive.
+13|Say, therefore, I am his sister, that it may be well with me on account of thee, and my soul shall live because of thee.
+14|And it came to pass when Abram entered into Egypt—the Egyptians having seen his wife that she was very beautiful—
+15|that the princes of Pharao saw her, and praised her to Pharao and brought her into the house of Pharao.
+16|And they treated Abram well on her account, and he had sheep, and calves, and asses, and men-servants, and women-servants, and mules, and camels.
+17|And God afflicted Pharao with great and severe afflictions, and his house, because of Sara, Abram's wife.
+18|And Pharao having called Abram, said, What is this thou hast done to me, that thou didst not tell me that she was thy wife?
+19|Wherefore didst thou say, She is my sister? and I took her for a wife to myself; and now, behold, thy wife is before thee, take her and go quickly away.
+20|And Pharao gave charge to men concerning Abram, to join in sending him forward, and his wife, and all that he had.
 
 #13
-1| And Abram went up out of Egypt, he and his wife, and all that he had, and Lot with him, into the wilderness. 
-2| And Abram was very rich in cattle, and silver, and gold. 
-3| And he went <i>to the place</i> whence he came, into the wilderness as far as Baethel, as far as the place where his tent was before, between Baethel and Aggai, 
-4| to the place of the altar, which he built there at first, and Abram there called on the name of the Lord. 
-5| And Lot who went out with Abram had sheep, and oxen, and tents. 
-6| And the land was not large enough for them to live together, because their possessions were great; and the land was not large enough for them to live together. 
-7| And there was a strife between the herdmen of Abram’s cattle, and the herdmen of Lot’s cattle, and the Chananites and the Pherezites then inhabited the land. 
-8| And Abram said to Lot, Let there not be a strife between me and thee, and between my herdmen and thy herdmen, for we are brethren. 
-9| Lo! is not the whole land before thee? Separate thyself from me; if thou <i>goest</i> to the left, I will go to the right, and if thou goest to the right, I will go to the left. 
-10| And Lot having lifted up his eyes, observed all the country round about Jordan, that it was all watered, before God overthrew Sodom and Gomorrha, as the garden of the Lord, and as the land of Egypt, until thou come to Zogora. 
-11| And Lot chose for himself all the country round Jordan, and Lot went from the east, and they were separated each from his brother. And Abram dwelt in the land of Chanaan. 
-12| And Lot dwelt in a city of the neighbouring people, and pitched his tent in Sodom. 
-13| But the men of Sodom were evil, and exceedingly sinful before God. 
-14| And God said to Abram after Lot was separated from him, Look up with thine eyes, and behold from the place where thou now art northward and southward, and eastward and seaward; 
-15| for all the land which thou seest, I will give it to thee and to thy seed for ever. 
-16| And I will make thy seed like the dust of the earth; if any one is able to number the dust of the earth, then shall thy seed be numbered. 
-17| Arise and traverse the land, both in the length of it and in the breadth; for to thee will I give it, and to thy seed for ever. 
-18| And Abram having removed his tent, came and dwelt by the oak of Mambre, which was in Chebrom, and he there built an altar to the Lord. 	4 	
+1|And Abram went up out of Egypt, he and his wife, and all that he had, and Lot with him, into the wilderness.
+2|And Abram was very rich in cattle, and silver, and gold.
+3|And he went <i>to the place</i> whence he came, into the wilderness as far as Baethel, as far as the place where his tent was before, between Baethel and Aggai,
+4|to the place of the altar, which he built there at first, and Abram there called on the name of the Lord.
+5|And Lot who went out with Abram had sheep, and oxen, and tents.
+6|And the land was not large enough for them to live together, because their possessions were great; and the land was not large enough for them to live together.
+7|And there was a strife between the herdmen of Abram's cattle, and the herdmen of Lot's cattle, and the Chananites and the Pherezites then inhabited the land.
+8|And Abram said to Lot, Let there not be a strife between me and thee, and between my herdmen and thy herdmen, for we are brethren.
+9|Lo! is not the whole land before thee? Separate thyself from me; if thou <i>goest</i> to the left, I will go to the right, and if thou goest to the right, I will go to the left.
+10|And Lot having lifted up his eyes, observed all the country round about Jordan, that it was all watered, before God overthrew Sodom and Gomorrha, as the garden of the Lord, and as the land of Egypt, until thou come to Zogora.
+11|And Lot chose for himself all the country round Jordan, and Lot went from the east, and they were separated each from his brother. And Abram dwelt in the land of Chanaan.
+12|And Lot dwelt in a city of the neighbouring people, and pitched his tent in Sodom.
+13|But the men of Sodom were evil, and exceedingly sinful before God.
+14|And God said to Abram after Lot was separated from him, Look up with thine eyes, and behold from the place where thou now art northward and southward, and eastward and seaward;
+15|for all the land which thou seest, I will give it to thee and to thy seed for ever.
+16|And I will make thy seed like the dust of the earth; if any one is able to number the dust of the earth, then shall thy seed be numbered.
+17|Arise and traverse the land, both in the length of it and in the breadth; for to thee will I give it, and to thy seed for ever.
+18|And Abram having removed his tent, came and dwelt by the oak of Mambre, which was in Chebrom, and he there built an altar to the Lord.
 
 #14
-1| And it came to pass in the reign of Amarphal king of Sennaar, and Arioch king of Ellasar, that Chodollogomor king of Elam, and Thargal king of nations, 
-2| made war with Balla king of Sodom, and with Barsa king of Gomorrha, and with Sennaar, king of Adama, and with Symobor king of Seboim and the king of Balac, this is Segor. 
-3| All these met with one consent at the salt valley; this is <i>now</i> the sea of salt. 
-4| Twelve years they served Chodollogomor, and the thirteenth year they revolted. 
-5| And in the fourteenth year came Chodollogomor, and the kings with him, and cut to pieces the giants in Astaroth, and Carnain, and strong nations with them, and the Ommaeans in the city Save. 
-6| And the Chorrhaeans in the mountains of Seir, to the turpentine tree of Pharan, which is in the desert. 
-7| And having turned back they came to the well of judgment; this is Cades, and they cut in pieces all the princes of Amalec, and the Amorites dwelling in Asasonthamar. 
-8| And the king of Sodom went out, and the king of Gomorrha, and king of Adama, and king of Seboim, and king of Balac, this is Segor, and they set themselves in array against them for war in the salt valley, 
-9| against Chodollogomor king of Elam, and Thargal king of nations, and Amarphal king of Sennaar, and Arioch king of Ellasar, the four kings against the five. 
-10| Now the salt valley <i>consists of</i> slime-pits. And the king of Sodom fled and the king of Gomorrha, and they fell in there: and they that were left fled to the mountain country. 
-11| And they took all the cavalry of Sodom and Gomorrha, and all their provisions, and departed. 
-12| And they took also Lot the son of Abram’s brother, and his baggage, and departed, for he dwelt in Sodom. 	
-13| And one of them that had been rescued came and told Abram the Hebrew; and he dwelt by the oak of Mamre the Amorite the brother of Eschol, and the brother of Aunan, who were confederates with Abram. 
-14| And Abram having heard that Lot his nephew had been taken captive, numbered his own home-born <i>servants</i> three hundred and eighteen, and pursued after them to Dan. 
-15| And he came upon them by night, he and his servants, and he smote them and pursued them as far as Choba, which is on the left of Damascus. 
-16| And he recovered all the cavalry of Sodom, and he recovered Lot his nephew, and all his possessions, and the women and the people. 
-17| And the king of Sodom went out to meet him, after he returned from the slaughter of Chodollogomor, and the kings with him, to the valley of Saby; this was the plain of the kings.  	
-18| And Melchisedec king of Salem brought forth loaves and wine, and he was the priest of the most high God. 
-19| And he blessed Abram, and said, Blessed be Abram of the most high God, who made heaven and earth, 
-20| and blessed be the most high God who delivered thine enemies into thy power. And Abram gave him the tithe of all. 
-21| And the king of Sodom said to Abram, Give me the men, and take the horses to thyself. 
-22| And Abram said to the king of Sodom, I will stretch out my hand to the Lord the most high God, who made the heaven and the earth, 
-23| <i>that</i> I will not take from all thy goods from a string to a shoe-latchet, lest thou shouldest say, I have made Abram rich. 
-24| Except what things the young men have eaten, and the portion of the men that went with me, Eschol, Aunan, Mambre, these shall take a portion. 	5 	
+1|And it came to pass in the reign of Amarphal king of Sennaar, and Arioch king of Ellasar, that Chodollogomor king of Elam, and Thargal king of nations,
+2|made war with Balla king of Sodom, and with Barsa king of Gomorrha, and with Sennaar, king of Adama, and with Symobor king of Seboim and the king of Balac, this is Segor.
+3|All these met with one consent at the salt valley; this is <i>now</i> the sea of salt.
+4|Twelve years they served Chodollogomor, and the thirteenth year they revolted.
+5|And in the fourteenth year came Chodollogomor, and the kings with him, and cut to pieces the giants in Astaroth, and Carnain, and strong nations with them, and the Ommaeans in the city Save.
+6|And the Chorrhaeans in the mountains of Seir, to the turpentine tree of Pharan, which is in the desert.
+7|And having turned back they came to the well of judgment; this is Cades, and they cut in pieces all the princes of Amalec, and the Amorites dwelling in Asasonthamar.
+8|And the king of Sodom went out, and the king of Gomorrha, and king of Adama, and king of Seboim, and king of Balac, this is Segor, and they set themselves in array against them for war in the salt valley,
+9|against Chodollogomor king of Elam, and Thargal king of nations, and Amarphal king of Sennaar, and Arioch king of Ellasar, the four kings against the five.
+10|Now the salt valley <i>consists of</i> slime-pits. And the king of Sodom fled and the king of Gomorrha, and they fell in there: and they that were left fled to the mountain country.
+11|And they took all the cavalry of Sodom and Gomorrha, and all their provisions, and departed.
+12|And they took also Lot the son of Abram's brother, and his baggage, and departed, for he dwelt in Sodom.
+13|And one of them that had been rescued came and told Abram the Hebrew; and he dwelt by the oak of Mamre the Amorite the brother of Eschol, and the brother of Aunan, who were confederates with Abram.
+14|And Abram having heard that Lot his nephew had been taken captive, numbered his own home-born <i>servants</i> three hundred and eighteen, and pursued after them to Dan.
+15|And he came upon them by night, he and his servants, and he smote them and pursued them as far as Choba, which is on the left of Damascus.
+16|And he recovered all the cavalry of Sodom, and he recovered Lot his nephew, and all his possessions, and the women and the people.
+17|And the king of Sodom went out to meet him, after he returned from the slaughter of Chodollogomor, and the kings with him, to the valley of Saby; this was the plain of the kings.
+18|And Melchisedec king of Salem brought forth loaves and wine, and he was the priest of the most high God.
+19|And he blessed Abram, and said, Blessed be Abram of the most high God, who made heaven and earth,
+20|and blessed be the most high God who delivered thine enemies into thy power. And Abram gave him the tithe of all.
+21|And the king of Sodom said to Abram, Give me the men, and take the horses to thyself.
+22|And Abram said to the king of Sodom, I will stretch out my hand to the Lord the most high God, who made the heaven and the earth,
+23|<i>that</i> I will not take from all thy goods from a string to a shoe-latchet, lest thou shouldest say, I have made Abram rich.
+24|Except what things the young men have eaten, and the portion of the men that went with me, Eschol, Aunan, Mambre, these shall take a portion.
 
 #15
-1| And after these things the word of the Lord came to Abram in a vision, saying, Fear not, Abram, I shield thee, thy reward shall be very great. 
-2| And Abram said, Master <i>and</i> Lord, what wilt thou give me? whereas I am departing without a child, but the son of Masek my home-born female slave, this Eliezer of Damascus <i>is mine heir.</i> 
-3| And Abram said, <i>I am grieved</i> since thou hast given me no seed, but my home-born <i>servant</i> shall succeed me. 
-4| And immediately there was a voice of the Lord to him, saying, This shall not be thine heir; but he that shall come out of thee shall be thine heir. 
-5| And he brought him out and said to him, Look up now to heaven, and count the stars, if thou shalt be able to number them fully, and he said, Thus shall thy seed be. 
-6| And Abram believed God, and it was counted to him for righteousness. 
-7| And he said to him, I am God that brought thee out of the land of the Chaldeans, so as to give thee this land to inherit. 
-8| And he said, Master <i>and</i> Lord, how shall I know that I shall inherit it? 
-9| And he said to him, Take for me an heifer in her third year, and a she-goat in her third year, and a ram in his third year, and a dove and a pigeon. 
-10| So he took to him all these, and divided them in the midst, and set them opposite to each other, but the birds he did not divide. 
-11| And birds came down upon the bodies, <i>even</i> upon the divided parts of them, and Abram sat down by them. 
-12| And about sunset a trance fell upon Abram, and lo! a great gloomy terror falls upon him. 
-13| And it was said to Abram, Thou shalt surely know that thy seed shall be a sojourner in a land not their won, and they shall enslave them, and afflict them, and humble them four hundred years. 
-14| And the nation whomsoever they shall serve I will judge; and after this, they shall come forth hither with much property. 
-15| But thou shalt depart to thy fathers in peace, nourished in a good old age. 
-16| And in the fourth generation they shall return hither, for the sins of the Amorites are not yet filled up, even until now.
- 17| And when the sun was about to set, there was a flame, and behold a smoking furnace and lamps of fire, which passed between these divided pieces. 
-18| In that day the Lord made a covenant with Abram, saying, To thy seed I will give this land, from the river of Egypt to the great river Euphrates. 
-19| The Kenites, and the Kenezites, and the Kedmoneans, 
-20| and the Chettites, and the Pherezites, and the Raphaim, 
-21| and the Amorites, and the Chananites, and the Evites, and the Gergesites, and the Jebusites. 	6 	
+1|And after these things the word of the Lord came to Abram in a vision, saying, Fear not, Abram, I shield thee, thy reward shall be very great.
+2|And Abram said, Master <i>and</i> Lord, what wilt thou give me? whereas I am departing without a child, but the son of Masek my home-born female slave, this Eliezer of Damascus <i>is mine heir.</i>
+3|And Abram said, <i>I am grieved</i> since thou hast given me no seed, but my home-born <i>servant</i> shall succeed me.
+4|And immediately there was a voice of the Lord to him, saying, This shall not be thine heir; but he that shall come out of thee shall be thine heir.
+5|And he brought him out and said to him, Look up now to heaven, and count the stars, if thou shalt be able to number them fully, and he said, Thus shall thy seed be.
+6|And Abram believed God, and it was counted to him for righteousness.
+7|And he said to him, I am God that brought thee out of the land of the Chaldeans, so as to give thee this land to inherit.
+8|And he said, Master <i>and</i> Lord, how shall I know that I shall inherit it?
+9|And he said to him, Take for me an heifer in her third year, and a she-goat in her third year, and a ram in his third year, and a dove and a pigeon.
+10|So he took to him all these, and divided them in the midst, and set them opposite to each other, but the birds he did not divide.
+11|And birds came down upon the bodies, <i>even</i> upon the divided parts of them, and Abram sat down by them.
+12|And about sunset a trance fell upon Abram, and lo! a great gloomy terror falls upon him.
+13|And it was said to Abram, Thou shalt surely know that thy seed shall be a sojourner in a land not their won, and they shall enslave them, and afflict them, and humble them four hundred years.
+14|And the nation whomsoever they shall serve I will judge; and after this, they shall come forth hither with much property.
+15|But thou shalt depart to thy fathers in peace, nourished in a good old age.
+16|And in the fourth generation they shall return hither, for the sins of the Amorites are not yet filled up, even until now.
+17|And when the sun was about to set, there was a flame, and behold a smoking furnace and lamps of fire, which passed between these divided pieces.
+18|In that day the Lord made a covenant with Abram, saying, To thy seed I will give this land, from the river of Egypt to the great river Euphrates.
+19|The Kenites, and the Kenezites, and the Kedmoneans,
+20|and the Chettites, and the Pherezites, and the Raphaim,
+21|and the Amorites, and the Chananites, and the Evites, and the Gergesites, and the Jebusites.
 
 #16
-1| And Sara the wife of Abram bore him no children; and she had an Egyptian maid, whose name was Agar. 
-2| And Sara said to Abram, Behold, the Lord has restrained me from bearing, go therefore in to my maid, that I may get children for myself through her. And Abram hearkened to the voice of Sara. 
-3| So Sara the wife of Abram having taken Agar the Egyptian her handmaid, after Abram had dwelt ten years in the land of Chanaan, gave her to Abram her husband as a wife to him. 
-4| And he went in to Agar, and she conceived, and saw that she was with child, and her mistress was dishonoured before her. 
-5| And Sara said to Abram, I am injured by thee; I gave my handmaid into thy bosom, and when I saw that she was with child, I was dishonoured before her. The Lord judge between me and thee. 
-6| And Abram said to Sara, Behold thy handmaid is in thy hands, use her as it may seem good to thee. And Sara afflicted her, and she fled from her face. 	
-7| And an angel of the Lord found her by the fountain of water in the wilderness, by the fountain in the way to Sur. 
-8| And the angel of the Lord said to her, Agar, Sara’s maid, whence comest thou, and wither goest thou? and she said, I am fleeing from the face of my mistress Sara. 
-9| And the angel of the Lord said to her, Return to thy mistress, and submit thyself under her hands. 
-10| And the angel of the Lord said to her, I will surely multiply thy seed, and it shall not be numbered for multitude. 
-11| And the angel of the Lord said to her, Behold thou art with child, and shalt bear a son, and shalt call his name Ismael, for the Lord hath hearkened to thy humiliation. 
-12| He shall be a wild man, his hands against all, and the hands of all against him, and he shall dwell in the presence of all his brethren. 
-13| And she called the name of the Lord God who spoke to her, Thou art God who seest me; for she said, For I have openly seen him that appeared to me. 
-14| Therefore she called the well, The well of him whom I have openly seen; behold it is between Cades and Barad. 
-15| And Agar bore a son to Abram; and Abram called the name of his son which Agar bore to him, Ismael. 
-16| And Abram was eighty-six years old, when Agar bore Ismael to Abram. 	7 	
+1|And Sara the wife of Abram bore him no children; and she had an Egyptian maid, whose name was Agar.
+2|And Sara said to Abram, Behold, the Lord has restrained me from bearing, go therefore in to my maid, that I may get children for myself through her. And Abram hearkened to the voice of Sara.
+3|So Sara the wife of Abram having taken Agar the Egyptian her handmaid, after Abram had dwelt ten years in the land of Chanaan, gave her to Abram her husband as a wife to him.
+4|And he went in to Agar, and she conceived, and saw that she was with child, and her mistress was dishonoured before her.
+5|And Sara said to Abram, I am injured by thee; I gave my handmaid into thy bosom, and when I saw that she was with child, I was dishonoured before her. The Lord judge between me and thee.
+6|And Abram said to Sara, Behold thy handmaid is in thy hands, use her as it may seem good to thee. And Sara afflicted her, and she fled from her face.
+7|And an angel of the Lord found her by the fountain of water in the wilderness, by the fountain in the way to Sur.
+8|And the angel of the Lord said to her, Agar, Sara's maid, whence comest thou, and wither goest thou? and she said, I am fleeing from the face of my mistress Sara.
+9|And the angel of the Lord said to her, Return to thy mistress, and submit thyself under her hands.
+10|And the angel of the Lord said to her, I will surely multiply thy seed, and it shall not be numbered for multitude.
+11|And the angel of the Lord said to her, Behold thou art with child, and shalt bear a son, and shalt call his name Ismael, for the Lord hath hearkened to thy humiliation.
+12|He shall be a wild man, his hands against all, and the hands of all against him, and he shall dwell in the presence of all his brethren.
+13|And she called the name of the Lord God who spoke to her, Thou art God who seest me; for she said, For I have openly seen him that appeared to me.
+14|Therefore she called the well, The well of him whom I have openly seen; behold it is between Cades and Barad.
+15|And Agar bore a son to Abram; and Abram called the name of his son which Agar bore to him, Ismael.
+16|And Abram was eighty-six years old, when Agar bore Ismael to Abram.
 
 #17
-1| And Abram was ninety-nine years old, and the Lord appeared to Abram and said to him, I am thy God, be well-pleasing before me, and be blameless. 
-2| And I will establish my covenant between me and thee, and I will multiply thee exceedingly. 
-3| And Abram fell upon his face, and God spoke to him, saying,
- 4| And I, behold! my covenant <i>is</i> with thee, and thou shalt be a father of a multitude of nations. 
-5| And thy name shall no more be called Abram, but thy name shall be Abraam, for I have made thee a father of many nations. 
-6| And I will increase thee very exceedingly, and I will make nations of thee, and kings shall come out of thee. 
-7| And I will establish my covenant between thee and thy seed after thee, to their generations, for an everlasting covenant, to be thy God, and <i>the God</i> of thy seed after thee. 
-8| And I will give to thee and to thy seed after thee the land wherein thou sojournest, even all the land of Chanaan for an everlasting possession, and I will be to them a God. 
-9| And God said to Abraam, Thou also shalt fully keep my covenant, thou and thy seed after thee for their generations. 
-10| And this <i>is</i> the covenant which thou shalt fully keep between me and you, and between thy seed after thee for their generations; every male of you shall be circumcised. 
-11| And ye shall be circumcised in the flesh of your foreskin, and it shall be for a sign of a covenant between me and you. 
-12| And the child of eight days <i>old</i> shall be circumcised by you, every male throughout your generations, and <i>the servant</i> born in the house and he that is bought with money, of every son of a stranger, who is not of thy seed. 
-13| He that is born in thy house, and he that is bought with money shall be surely circumcised, and my covenant shall be on your flesh for an everlasting covenant. 
-14| And the uncircumcised male, who shall not be circumcised in the flesh of his foreskin on the eighth day, that soul shall be utterly destroyed from its family, for he has broken my covenant.
- 15| And God said to Abraam, Sara thy wife—her name shall not be called Sara, Sarrha shall be her name. 
-16| And I will bless her, and give thee a son of her, and I will bless him, and he shall become nations, and kings of nations shall be of him. 
-17| And Abraam fell upon his face, and laughed; and spoke in his heart, saying, Shall there be a child to one who is a hundred years old, and shall Sarrha who is ninety years old, bear? 
-18| And Abraam said to God, Let this Ismael live before thee. 
-19| And God said to Abraam, Yea, behold, Sarrha thy wife shall bear thee a son, and thou shalt call his name Isaac; and I will establish my covenant with him, for an everlasting covenant, to be a God to him and to his seed after him. 
-20| And concerning Ismael, behold, I have heard thee, and, behold, I have blessed him, and will increase him and multiply him exceedingly; twelve nations shall he beget, and I will make him a great nation. 
-21| But I will establish my covenant with Isaac, whom Sarrha shall bear to thee at this time, in the next year. 
-22| And he left off speaking with him, and God went up from Abraam. 	
-23| And Abraam took Ismael his son, and all his home-born <i>servants</i>, and all those bought with money, and every male of the men in the house of Abraam, and he circumcised their foreskins in the time of that day, according as God spoke to him. 
-24| And Abraam was ninety-nine years old, when he was circumcised in the flesh of his foreskin. 
-25| And Ismael his son was thirteen years old when he was circumcised in the flesh of his foreskin. 
-26| And at the period of that day, Abraam was circumcised, and Ismael his son, 
-27| and all the men of his house, both those born in the house, and those bought with money of foreign nations. 	8 	
+1|And Abram was ninety-nine years old, and the Lord appeared to Abram and said to him, I am thy God, be well-pleasing before me, and be blameless.
+2|And I will establish my covenant between me and thee, and I will multiply thee exceedingly.
+3|And Abram fell upon his face, and God spoke to him, saying,
+4|And I, behold! my covenant <i>is</i> with thee, and thou shalt be a father of a multitude of nations.
+5|And thy name shall no more be called Abram, but thy name shall be Abraam, for I have made thee a father of many nations.
+6|And I will increase thee very exceedingly, and I will make nations of thee, and kings shall come out of thee.
+7|And I will establish my covenant between thee and thy seed after thee, to their generations, for an everlasting covenant, to be thy God, and <i>the God</i> of thy seed after thee.
+8|And I will give to thee and to thy seed after thee the land wherein thou sojournest, even all the land of Chanaan for an everlasting possession, and I will be to them a God.
+9|And God said to Abraam, Thou also shalt fully keep my covenant, thou and thy seed after thee for their generations.
+10|And this <i>is</i> the covenant which thou shalt fully keep between me and you, and between thy seed after thee for their generations; every male of you shall be circumcised.
+11|And ye shall be circumcised in the flesh of your foreskin, and it shall be for a sign of a covenant between me and you.
+12|And the child of eight days <i>old</i> shall be circumcised by you, every male throughout your generations, and <i>the servant</i> born in the house and he that is bought with money, of every son of a stranger, who is not of thy seed.
+13|He that is born in thy house, and he that is bought with money shall be surely circumcised, and my covenant shall be on your flesh for an everlasting covenant.
+14|And the uncircumcised male, who shall not be circumcised in the flesh of his foreskin on the eighth day, that soul shall be utterly destroyed from its family, for he has broken my covenant.
+15|And God said to Abraam, Sara thy wife—her name shall not be called Sara, Sarrha shall be her name.
+16|And I will bless her, and give thee a son of her, and I will bless him, and he shall become nations, and kings of nations shall be of him.
+17|And Abraam fell upon his face, and laughed; and spoke in his heart, saying, Shall there be a child to one who is a hundred years old, and shall Sarrha who is ninety years old, bear?
+18|And Abraam said to God, Let this Ismael live before thee.
+19|And God said to Abraam, Yea, behold, Sarrha thy wife shall bear thee a son, and thou shalt call his name Isaac; and I will establish my covenant with him, for an everlasting covenant, to be a God to him and to his seed after him.
+20|And concerning Ismael, behold, I have heard thee, and, behold, I have blessed him, and will increase him and multiply him exceedingly; twelve nations shall he beget, and I will make him a great nation.
+21|But I will establish my covenant with Isaac, whom Sarrha shall bear to thee at this time, in the next year.
+22|And he left off speaking with him, and God went up from Abraam.
+23|And Abraam took Ismael his son, and all his home-born <i>servants</i>, and all those bought with money, and every male of the men in the house of Abraam, and he circumcised their foreskins in the time of that day, according as God spoke to him.
+24|And Abraam was ninety-nine years old, when he was circumcised in the flesh of his foreskin.
+25|And Ismael his son was thirteen years old when he was circumcised in the flesh of his foreskin.
+26|And at the period of that day, Abraam was circumcised, and Ismael his son,
+27|and all the men of his house, both those born in the house, and those bought with money of foreign nations.
 
 #18
-1| And God appeared to him by the oak of Mambre, as he sat by the door of his tent at noon. 
-2| And he lifted up his eyes and beheld, and lo! three men stood before him; and having seen them he ran to meet them from the door of his tent, and did obeisance to the ground. 
-3| And he said, Lord, if indeed I have found grace in thy sight, pass not by thy servant. 
-4| Let water now be brought, and let them wash your feet, and do ye refresh <i>yourselves</i> under the tree. 
-5| And I will bring bread, and ye shall eat, and after this ye shall depart on your journey, on account of which <i>refreshment</i> ye have turned aside to your servant. And he said, So do, as thou hast said. 
-6| And Abraam hasted to the tent to Sarrha, and said to her, Hasten, and knead three measures of fine flour, and make cakes. 
-7| And Abraam ran to the kine, and took a young calf, tender and good, and gave it to his servant, and he hasted to dress it. 
-8| And he took butter and milk, and the calf which he had dressed; and he set them before them, and they did eat, and he stood by them under the tree. 	
-9| And he said to him, Where is Sarrha thy wife? And he answered and said, Behold! in the tent. 
-10| And he said, I will return and come to thee according to this period seasonably, and Sarrha thy wife shall have a son; and Sarrha heard at the door of the tent, being behind him. 
-11| And Abraam and Sarrha were old, advanced in days, and the custom of women ceased with Sarrha. 
-12| And Sarrha laughed in herself, saying, The thing has not as yet happened to me, even until now, and my lord is old. 
-13| And the Lord said to Abraam, Why is it that Sarrha has laughed in herself, saying, Shall I then indeed bear? but I am grown old. 
-14| Shall anything be impossible with the Lord? At this time I will return to thee seasonably, and Sarrha shall have a son. 
-15| But Sarrha denied, saying, I did not laugh, for she was afraid. And he said to her, Nay, but thou didst laugh. 	
-16| And the men having risen up from thence looked towards Sodom and Gomorrha. And Abraam went with them, attending them on their journey. 
-17| And the Lord said, Shall I hide from Abraam my servant what things I intend to do? 
-18| But Abraam shall become a great and populous nation, and in him shall all the nations of the earth be blest. 
-19| For I know that he will order his sons, and his house after him, and they will keep the ways of the Lord, to do justice and judgment, that the Lord may bring upon Abraam all things whatsoever he has spoken to him. 
-20| And the Lord said, The cry of Sodom and Gomorrha has been increased towards me, and their sins are very great. 
-21| I will therefore go down and see, if they completely correspond with the cry which comes to me, and if not, that I may know. 
-22| And the men having departed thence, came to Sodom; and Abraam was still standing before the Lord. 
-23| And Abraam drew nigh and said, Wouldest thou destroy the righteous with the wicked, and shall the righteous be as the wicked? 
-24| Should there be fifty righteous in the city, wilt thou destroy them? wilt thou not spare the whole place for the sake of the fifty righteous, if they be in it? 
-25| By no means shalt thou do as this thing <i>is</i> so as to destroy the righteous with the wicked, so the righteous shall be as the wicked: by no means. Thou that judgest the whole earth, shalt thou not do right? 
-26| And the Lord said, If there should be in Sodom fifty righteous in the city, I will spare the whole city, and the whole place for their sakes. 
-27| And Abraam answered and said, Now I have begun to speak to my Lord, and I am earth and ashes. 
-28| But if the fifty righteous should be diminished to forty-five, wilt thou destroy the whole city because of the five <i>wanting</i>? And he said, I will not destroy it, if I should find there forty-five. 
-29| And he continued to speak to him still, and said, But if there should be found there forty? And he said, I will not destroy it for the forty’s sake. 
-30| And he said, Will there be anything <i>against me</i>, Lord, if I shall speak? but if there be found there thirty? And he said, I will not destroy it for the thirty’s sake. 
-31| And he said, Since I am able to speak to the Lord, what if there should be found there twenty? And he said, I will not destroy it, if I should find there twenty. 
-32| And he said, Will there be anything <i>against me</i>, Lord, if I speak yet once? but if there should be found there ten? And he said, I will not destroy it for the ten’s sake. 
-33| And the Lord departed, when he left off speaking to Abraam, and Abraam returned to his place. 	9 	
+1|And God appeared to him by the oak of Mambre, as he sat by the door of his tent at noon.
+2|And he lifted up his eyes and beheld, and lo! three men stood before him; and having seen them he ran to meet them from the door of his tent, and did obeisance to the ground.
+3|And he said, Lord, if indeed I have found grace in thy sight, pass not by thy servant.
+4|Let water now be brought, and let them wash your feet, and do ye refresh <i>yourselves</i> under the tree.
+5|And I will bring bread, and ye shall eat, and after this ye shall depart on your journey, on account of which <i>refreshment</i> ye have turned aside to your servant. And he said, So do, as thou hast said.
+6|And Abraam hasted to the tent to Sarrha, and said to her, Hasten, and knead three measures of fine flour, and make cakes.
+7|And Abraam ran to the kine, and took a young calf, tender and good, and gave it to his servant, and he hasted to dress it.
+8|And he took butter and milk, and the calf which he had dressed; and he set them before them, and they did eat, and he stood by them under the tree.
+9|And he said to him, Where is Sarrha thy wife? And he answered and said, Behold! in the tent.
+10|And he said, I will return and come to thee according to this period seasonably, and Sarrha thy wife shall have a son; and Sarrha heard at the door of the tent, being behind him.
+11|And Abraam and Sarrha were old, advanced in days, and the custom of women ceased with Sarrha.
+12|And Sarrha laughed in herself, saying, The thing has not as yet happened to me, even until now, and my lord is old.
+13|And the Lord said to Abraam, Why is it that Sarrha has laughed in herself, saying, Shall I then indeed bear? but I am grown old.
+14|Shall anything be impossible with the Lord? At this time I will return to thee seasonably, and Sarrha shall have a son.
+15|But Sarrha denied, saying, I did not laugh, for she was afraid. And he said to her, Nay, but thou didst laugh.
+16|And the men having risen up from thence looked towards Sodom and Gomorrha. And Abraam went with them, attending them on their journey.
+17|And the Lord said, Shall I hide from Abraam my servant what things I intend to do?
+18|But Abraam shall become a great and populous nation, and in him shall all the nations of the earth be blest.
+19|For I know that he will order his sons, and his house after him, and they will keep the ways of the Lord, to do justice and judgment, that the Lord may bring upon Abraam all things whatsoever he has spoken to him.
+20|And the Lord said, The cry of Sodom and Gomorrha has been increased towards me, and their sins are very great.
+21|I will therefore go down and see, if they completely correspond with the cry which comes to me, and if not, that I may know.
+22|And the men having departed thence, came to Sodom; and Abraam was still standing before the Lord.
+23|And Abraam drew nigh and said, Wouldest thou destroy the righteous with the wicked, and shall the righteous be as the wicked?
+24|Should there be fifty righteous in the city, wilt thou destroy them? wilt thou not spare the whole place for the sake of the fifty righteous, if they be in it?
+25|By no means shalt thou do as this thing <i>is</i> so as to destroy the righteous with the wicked, so the righteous shall be as the wicked: by no means. Thou that judgest the whole earth, shalt thou not do right?
+26|And the Lord said, If there should be in Sodom fifty righteous in the city, I will spare the whole city, and the whole place for their sakes.
+27|And Abraam answered and said, Now I have begun to speak to my Lord, and I am earth and ashes.
+28|But if the fifty righteous should be diminished to forty-five, wilt thou destroy the whole city because of the five <i>wanting</i>? And he said, I will not destroy it, if I should find there forty-five.
+29|And he continued to speak to him still, and said, But if there should be found there forty? And he said, I will not destroy it for the forty's sake.
+30|And he said, Will there be anything <i>against me</i>, Lord, if I shall speak? but if there be found there thirty? And he said, I will not destroy it for the thirty's sake.
+31|And he said, Since I am able to speak to the Lord, what if there should be found there twenty? And he said, I will not destroy it, if I should find there twenty.
+32|And he said, Will there be anything <i>against me</i>, Lord, if I speak yet once? but if there should be found there ten? And he said, I will not destroy it for the ten's sake.
+33|And the Lord departed, when he left off speaking to Abraam, and Abraam returned to his place.
 
 #19
-1| And the two angels came to Sodom at evening. And Lot sat by the gate of Sodom, and Lot having seen them, rose up to meet them, and he worshipped with his face to the ground, and said, 
-2| Lo! <i>my</i> lords, turn aside to the house of your servant, and rest from your journey, and wash your feet, and having risen early in the morning ye shall depart on your journey. And they said, Nay, but we will lodge in the street. 
-3| And he constrained them, and they turned aside to him, and they entered into his house, and he made a feast for them, and baked unleavened cakes for them, and they did eat. 
-4| But before they went to sleep, the men of the city, the Sodomites, compassed the house, both young and old, all the people together. 
-5| And they called out Lot, and said to him, Where are the men that went in to thee this night? bring them out to us that we may be with them. 
-6| And Lot went out to them to the porch, and he shut the door after him, 
-7| and said to them, By no means, brethren, do not act villanously. 
-8| But I have two daughters, who have not known a man. I will bring them out to you, and do ye use them as it may please you, only do not injury to these men, to avoid which they came under the shelter of my roof. 
-9| And they said to him, Stand back there, thou camest in to sojourn, was it also to judge? Now then we would harm thee more than them. And they pressed hard on the man, even Lot, and they drew nigh to break the door. 
-10| And the men stretched forth their hands and drew Lot in to them into the house, and shut the door of the house. 
-11| And they smote the men that were at the door of the house with blindness, both small and great, and they were wearied with seeking the door.
- 12| And the men said to Lot, Hast thou here sons-in-law, or sons or daughters, or if thou hast any other friend in the city, bring them out of this place. 
-13| For we are going to destroy this place; for their cry has been raised up before the Lord, and the Lord has sent us to destroy it. 
-14| And Lot went out, and spoke to his sons-in-law who had married his daughters, and said, Rise up, and depart out of this place, for the Lord is about to destroy the city; but he seemed to be speaking absurdly before his sons-in-law.
- 15| But when it was morning, the angels hastened Lot, saying, Arise and take thy wife, and thy two daughters whom thou hast, and go forth; lest thou also be destroyed with the iniquities of the city. 
-16| And they were troubled, and the angels laid hold on his hand, and the hand of his wife, and the hands of his two daughters, in that the Lord spared him.  	
-17| And it came to pass when they brought them out, that they said, Save thine own life by all means; look not round to that which is behind, nor stay in all the country round about, escape to the mountain, lest perhaps thou be overtaken together with them. 
-18| And Lot said to them, I pray, Lord, 
-19| since thy servant has found mercy before thee, and thou hast magnified thy righteousness, in what thou doest towards me that my soul may live, —but I shall not be able to escape to the mountain, lest perhaps the calamity overtake me and I die. 
-20| Behold this city is near for me to escape thither, which is a small one, and there shall I be preserved, is it not little? and my soul shall live because of thee. 
-21| And he said to him, Behold, I have had respect to thee also about this thing, that I should not overthrow the city about which thou hast spoken. 
-22| Hasten therefore to escape thither, for I shall not be able to do anything until thou art come thither; therefore he called the name of that city, Segor. 
-23| The sun was risen upon the earth, when Lot entered into Segor. 
-24| And the Lord rained on Sodom and Gomorrha brimstone and fire from the Lord out of heaven. 
-25| And he overthrew these cities, and all the country round about, and all that dwelt in the cities, and the plants springing out of the ground.
- 26| And his wife looked back, and she became a pillar of salt. 
-27| And Abraam rose up early to go to the place, where he had stood before the Lord. 
-28| And he looked towards Sodom and Gomorrha, and towards the surrounding country, and saw, and behold a flame went up from the earth, as the smoke of a furnace. 
-29| And it came to pass that when God destroyed all the cities of the region round about, God remembered Abraam, and sent Lot out of the midst of the overthrow, when the Lord overthrew those cities in which Lot dwelt. 	
-30| And Lot went up out of Segor, and dwelt in the mountain, he and his two daughters with him, for he feared to dwell in Segor; and he dwelt in a cave, he and his two daughters with him. 
-31| And the elder said to the younger, Our father is old, and there is no one on the earth who shall come in to us, as it is fit in all the earth. 
-32| Come and let us make our father drink wine, and let us sleep with him, and let us raise up seed from our father. 
-33| So they made their father drink wine in that night, and the elder went in and lay with her father that night, and he knew not when he slept and when he rose up. 
-34| And it came to pass on the morrow, that the elder said to the younger, Behold, I slept yesternight with our father, let us make him drink wine in this night also, and do thou go in and sleep with him, and let us raise up seed of our father. 
-35| So they made their father drink wine in that night also, and the younger went in and slept with her father, and he knew not when he slept, nor when he arose. 
-36| And the two daughters of Lot conceived by their father. 
-37| And the elder bore a son and called his name Moab, saying, <i>He is</i> of my father. This is the father of the Moabites to this present day. 
-38| And the younger also bore a son, and called his name Amman, saying, The son of my family. This is the father of the Ammanites to this present day. 	0 	
+1|And the two angels came to Sodom at evening. And Lot sat by the gate of Sodom, and Lot having seen them, rose up to meet them, and he worshipped with his face to the ground, and said,
+2|Lo! <i>my</i> lords, turn aside to the house of your servant, and rest from your journey, and wash your feet, and having risen early in the morning ye shall depart on your journey. And they said, Nay, but we will lodge in the street.
+3|And he constrained them, and they turned aside to him, and they entered into his house, and he made a feast for them, and baked unleavened cakes for them, and they did eat.
+4|But before they went to sleep, the men of the city, the Sodomites, compassed the house, both young and old, all the people together.
+5|And they called out Lot, and said to him, Where are the men that went in to thee this night? bring them out to us that we may be with them.
+6|And Lot went out to them to the porch, and he shut the door after him,
+7|and said to them, By no means, brethren, do not act villanously.
+8|But I have two daughters, who have not known a man. I will bring them out to you, and do ye use them as it may please you, only do not injury to these men, to avoid which they came under the shelter of my roof.
+9|And they said to him, Stand back there, thou camest in to sojourn, was it also to judge? Now then we would harm thee more than them. And they pressed hard on the man, even Lot, and they drew nigh to break the door.
+10|And the men stretched forth their hands and drew Lot in to them into the house, and shut the door of the house.
+11|And they smote the men that were at the door of the house with blindness, both small and great, and they were wearied with seeking the door.
+12|And the men said to Lot, Hast thou here sons-in-law, or sons or daughters, or if thou hast any other friend in the city, bring them out of this place.
+13|For we are going to destroy this place; for their cry has been raised up before the Lord, and the Lord has sent us to destroy it.
+14|And Lot went out, and spoke to his sons-in-law who had married his daughters, and said, Rise up, and depart out of this place, for the Lord is about to destroy the city; but he seemed to be speaking absurdly before his sons-in-law.
+15|But when it was morning, the angels hastened Lot, saying, Arise and take thy wife, and thy two daughters whom thou hast, and go forth; lest thou also be destroyed with the iniquities of the city.
+16|And they were troubled, and the angels laid hold on his hand, and the hand of his wife, and the hands of his two daughters, in that the Lord spared him.
+17|And it came to pass when they brought them out, that they said, Save thine own life by all means; look not round to that which is behind, nor stay in all the country round about, escape to the mountain, lest perhaps thou be overtaken together with them.
+18|And Lot said to them, I pray, Lord,
+19|since thy servant has found mercy before thee, and thou hast magnified thy righteousness, in what thou doest towards me that my soul may live, —but I shall not be able to escape to the mountain, lest perhaps the calamity overtake me and I die.
+20|Behold this city is near for me to escape thither, which is a small one, and there shall I be preserved, is it not little? and my soul shall live because of thee.
+21|And he said to him, Behold, I have had respect to thee also about this thing, that I should not overthrow the city about which thou hast spoken.
+22|Hasten therefore to escape thither, for I shall not be able to do anything until thou art come thither; therefore he called the name of that city, Segor.
+23|The sun was risen upon the earth, when Lot entered into Segor.
+24|And the Lord rained on Sodom and Gomorrha brimstone and fire from the Lord out of heaven.
+25|And he overthrew these cities, and all the country round about, and all that dwelt in the cities, and the plants springing out of the ground.
+26|And his wife looked back, and she became a pillar of salt.
+27|And Abraam rose up early to go to the place, where he had stood before the Lord.
+28|And he looked towards Sodom and Gomorrha, and towards the surrounding country, and saw, and behold a flame went up from the earth, as the smoke of a furnace.
+29|And it came to pass that when God destroyed all the cities of the region round about, God remembered Abraam, and sent Lot out of the midst of the overthrow, when the Lord overthrew those cities in which Lot dwelt.
+30|And Lot went up out of Segor, and dwelt in the mountain, he and his two daughters with him, for he feared to dwell in Segor; and he dwelt in a cave, he and his two daughters with him.
+31|And the elder said to the younger, Our father is old, and there is no one on the earth who shall come in to us, as it is fit in all the earth.
+32|Come and let us make our father drink wine, and let us sleep with him, and let us raise up seed from our father.
+33|So they made their father drink wine in that night, and the elder went in and lay with her father that night, and he knew not when he slept and when he rose up.
+34|And it came to pass on the morrow, that the elder said to the younger, Behold, I slept yesternight with our father, let us make him drink wine in this night also, and do thou go in and sleep with him, and let us raise up seed of our father.
+35|So they made their father drink wine in that night also, and the younger went in and slept with her father, and he knew not when he slept, nor when he arose.
+36|And the two daughters of Lot conceived by their father.
+37|And the elder bore a son and called his name Moab, saying, <i>He is</i> of my father. This is the father of the Moabites to this present day.
+38|And the younger also bore a son, and called his name Amman, saying, The son of my family. This is the father of the Ammanites to this present day.
 
 #20
-1| And Abraam removed thence to the southern country, and dwelt between Cades and Sur, and sojourned in Gerara. 
-2| And Abraam said concerning Sarrha his wife, She is my sister, for he feared to say, She is my wife, lest at any time the men of the city should kill him for her sake. So Abimelech king of Gerara sent and took Sarrha. 
-3| And God came to Abimelech by night in sleep, and said, Behold, thou diest for the woman, whom thou hast taken, whereas she has lived with a husband. 
-4| But Abimelech had not touched her, and he said, Lord, wilt thou destroy an ignorantly <i>sinning</i> and just nation? 
-5| Said he not to me, She is my sister, and said she not to me, He is my brother? with a pure heart and in the righteousness of my hands have I done this. 
-6| And God said to him in sleep, Yea, I knew that thou didst this with a pure heart, and I spared thee, so that thou shouldest not sin against me, therefore I suffered thee not to touch her. 
-7| But now return the man his wife; for he is a prophet, and shall pray for thee, and thou shalt live; but if thou restore her not, know that thou shalt die and all thine. 
-8| And Abimelech rose early in the morning, and called all his servants, and he spoke all these words in their ears, and all the men feared exceedingly. 
-9| And Abimelech called Abraam and said to him, What is this that thou hast done to us? Have we sinned against thee, that thou hast brought upon me and upon my kingdom a great sin? Thou hast done to me a deed, which no one ought to do. 
-10| And Abimelech said to Abraam, What hast thou seen in <i>me</i> that thou hast done this? 
-11| And Abraam said, Why I said, Surely there is not the worship of God in this place, and they will slay me because of my wife. 
-12| For truly she is my sister by my father, but not by my mother, and she became my wife. 
-13| And it came to pass when God brought me forth out of the house of my father, that I said to her, This righteousness thou shalt perform to me, in every place into which we may enter, say of me, He is my brother. 
-14| And Abimelech took a thousand pieces of silver, and sheep, and calves, and servants, and maid-servants, and gave them to Abraam, and he returned him Sarrha his wife. 
-15| And Abimelech said to Abraam, Behold, my land is before thee, dwell wheresoever it may please thee. 
-16| And to Sarrha he said, Behold, I have given thy brother a thousand pieces of silver, those shall be to thee for the price of thy countenance, and to all the women with thee, and speak the truth in all things. 
-17| And Abraam prayed to God, and God healed Abimelech, and his wife, and his women servants, and they bore children. 
-18| Because the Lord had fast closed from without every womb in the house of Abimelech, because of Sarrha Abraam’s wife. 	1 	
+1|And Abraam removed thence to the southern country, and dwelt between Cades and Sur, and sojourned in Gerara.
+2|And Abraam said concerning Sarrha his wife, She is my sister, for he feared to say, She is my wife, lest at any time the men of the city should kill him for her sake. So Abimelech king of Gerara sent and took Sarrha.
+3|And God came to Abimelech by night in sleep, and said, Behold, thou diest for the woman, whom thou hast taken, whereas she has lived with a husband.
+4|But Abimelech had not touched her, and he said, Lord, wilt thou destroy an ignorantly <i>sinning</i> and just nation?
+5|Said he not to me, She is my sister, and said she not to me, He is my brother? with a pure heart and in the righteousness of my hands have I done this.
+6|And God said to him in sleep, Yea, I knew that thou didst this with a pure heart, and I spared thee, so that thou shouldest not sin against me, therefore I suffered thee not to touch her.
+7|But now return the man his wife; for he is a prophet, and shall pray for thee, and thou shalt live; but if thou restore her not, know that thou shalt die and all thine.
+8|And Abimelech rose early in the morning, and called all his servants, and he spoke all these words in their ears, and all the men feared exceedingly.
+9|And Abimelech called Abraam and said to him, What is this that thou hast done to us? Have we sinned against thee, that thou hast brought upon me and upon my kingdom a great sin? Thou hast done to me a deed, which no one ought to do.
+10|And Abimelech said to Abraam, What hast thou seen in <i>me</i> that thou hast done this?
+11|And Abraam said, Why I said, Surely there is not the worship of God in this place, and they will slay me because of my wife.
+12|For truly she is my sister by my father, but not by my mother, and she became my wife.
+13|And it came to pass when God brought me forth out of the house of my father, that I said to her, This righteousness thou shalt perform to me, in every place into which we may enter, say of me, He is my brother.
+14|And Abimelech took a thousand pieces of silver, and sheep, and calves, and servants, and maid-servants, and gave them to Abraam, and he returned him Sarrha his wife.
+15|And Abimelech said to Abraam, Behold, my land is before thee, dwell wheresoever it may please thee.
+16|And to Sarrha he said, Behold, I have given thy brother a thousand pieces of silver, those shall be to thee for the price of thy countenance, and to all the women with thee, and speak the truth in all things.
+17|And Abraam prayed to God, and God healed Abimelech, and his wife, and his women servants, and they bore children.
+18|Because the Lord had fast closed from without every womb in the house of Abimelech, because of Sarrha Abraam's wife.
 
 #21
-1| And the Lord visited Sarrha, as he said, and the Lord did to Sarrha, as he spoke. 
-2| And she conceived and bore to Abraam a son in old age, at the set time according as the Lord spoke to him. 
-3| And Abraam called the name of his son that was born to him, whom Sarrha bore to him, Isaac. 
-4| And Abraam circumcised Isaac on the eighth day, as God commanded him. 
-5| And Abraam was a hundred years old when Isaac his son was born to him. 
-6| And Sarrha said, The Lord has made laughter for me, for whoever shall hear shall rejoice with me. 
-7| And she said, Who shall say to Abraam that Sarrha suckles a child? for I have born a child in my old age. 
-8| And the child grew and was weaned, and Abraam made a great feast the day that his son Isaac was weaned. 
-9| And Sarrha having seen the son of Agar the Egyptian who was born to Abraam, sporting with Isaac her son, 
-10| then she said to Abraam, Cast out this bondwoman and her son, for the son of this bondwoman shall not inherit with my son Isaac. 
-11| But the word appeared very hard before Abraam concerning his son. 
-12| But God said to Abraam, Let it not be hard before thee concerning the child, and concerning the bondwoman; in all things whatsoever Sarrha shall say to thee, hear her voice, for in Isaac shall thy seed be called. 
-13| And moreover I will make the son of this bondwoman a great nation, because he is thy seed. 
-14| And Abraam rose up in the morning and took loaves and a skin of water, and gave <i>them</i> to Agar, and he put the child on her shoulder, and sent her away, and she having departed wandered in the wilderness near the well of the oath. 
-15| And the water failed out of the skin, and she cast the child under a fir tree. 
-16| And she departed and sat down opposite him at a distance, as it were a bow-shot, for she said, Surely I cannot see the death of my child: and she sat opposite him, and the child cried aloud and wept. 
-17| And God heard the voice of the child from the place where he was, and an angel of God called Agar out of heaven, and said to her, What is it, Agar? fear not, for God has heard the voice of the child from the place where he is. 
-18| Rise up, and take the child, and hold him in thine hand, for I will make him a great nation. 
-19| And God opened her eyes, and she saw a well of springing water; and she went and filled the skin with water, and gave the child drink. 
-20| And God was with the child, and he grew and dwelt in the wilderness, and became an archer. 
-21| And he dwelt in the wilderness, and his mother took him a wife out of Pharan of Egypt. 	
-22| And it came to pass at that time that Abimelech spoke, and Ochozath his friend, and Phichol the chief captain of his host, to Abraam, saying, God is with thee in all things, whatsoever thou mayest do. 
-23| Now therefore swear to me by God that thou wilt not injure me, nor my seed, nor my name, but according to the righteousness which I have performed with thee thou shalt deal with me, and with the land in which thou hast sojourned. 
-24| And Abraam said, I will swear. 
-25| And Abraam reproved Abimelech because of the wells of water, which the servants of Abimelech took away. 
-26| And Abimelech said to him, I know not who has done this thing to thee, neither didst thou tell it me, neither heard I it but only to-day. 
-27| And Abraam took sheep and calves, and gave them to Abimelech, and both made a covenant. 
-28| And Abraam set seven ewe-lambs by themselves. 
-29| And Abimelech said to Abraam, What are these seven ewe-lambs which thou hast set alone? 
-30| And Abraam said, Thou shalt receive the seven ewe-lambs of me, that they may be for me as a witness, that I dug this well. 
-31| Therefore he named the name of that place, The Well of the Oath, for there they both swore. 
-32| And they made a covenant at the well of the oath. And there rose up Abimelech, Ochozath his friend, and Phichol the commander-in-chief of his army, and they returned to the land of the Phylistines.
- 33| And Abraam planted a field at the well of the oath, and called there on the name of the Lord, the everlasting God. 
-34| And Abraam sojourned in the land of the Phylistines many days. 	2 	
+1|And the Lord visited Sarrha, as he said, and the Lord did to Sarrha, as he spoke.
+2|And she conceived and bore to Abraam a son in old age, at the set time according as the Lord spoke to him.
+3|And Abraam called the name of his son that was born to him, whom Sarrha bore to him, Isaac.
+4|And Abraam circumcised Isaac on the eighth day, as God commanded him.
+5|And Abraam was a hundred years old when Isaac his son was born to him.
+6|And Sarrha said, The Lord has made laughter for me, for whoever shall hear shall rejoice with me.
+7|And she said, Who shall say to Abraam that Sarrha suckles a child? for I have born a child in my old age.
+8|And the child grew and was weaned, and Abraam made a great feast the day that his son Isaac was weaned.
+9|And Sarrha having seen the son of Agar the Egyptian who was born to Abraam, sporting with Isaac her son,
+10|then she said to Abraam, Cast out this bondwoman and her son, for the son of this bondwoman shall not inherit with my son Isaac.
+11|But the word appeared very hard before Abraam concerning his son.
+12|But God said to Abraam, Let it not be hard before thee concerning the child, and concerning the bondwoman; in all things whatsoever Sarrha shall say to thee, hear her voice, for in Isaac shall thy seed be called.
+13|And moreover I will make the son of this bondwoman a great nation, because he is thy seed.
+14|And Abraam rose up in the morning and took loaves and a skin of water, and gave <i>them</i> to Agar, and he put the child on her shoulder, and sent her away, and she having departed wandered in the wilderness near the well of the oath.
+15|And the water failed out of the skin, and she cast the child under a fir tree.
+16|And she departed and sat down opposite him at a distance, as it were a bow-shot, for she said, Surely I cannot see the death of my child: and she sat opposite him, and the child cried aloud and wept.
+17|And God heard the voice of the child from the place where he was, and an angel of God called Agar out of heaven, and said to her, What is it, Agar? fear not, for God has heard the voice of the child from the place where he is.
+18|Rise up, and take the child, and hold him in thine hand, for I will make him a great nation.
+19|And God opened her eyes, and she saw a well of springing water; and she went and filled the skin with water, and gave the child drink.
+20|And God was with the child, and he grew and dwelt in the wilderness, and became an archer.
+21|And he dwelt in the wilderness, and his mother took him a wife out of Pharan of Egypt.
+22|And it came to pass at that time that Abimelech spoke, and Ochozath his friend, and Phichol the chief captain of his host, to Abraam, saying, God is with thee in all things, whatsoever thou mayest do.
+23|Now therefore swear to me by God that thou wilt not injure me, nor my seed, nor my name, but according to the righteousness which I have performed with thee thou shalt deal with me, and with the land in which thou hast sojourned.
+24|And Abraam said, I will swear.
+25|And Abraam reproved Abimelech because of the wells of water, which the servants of Abimelech took away.
+26|And Abimelech said to him, I know not who has done this thing to thee, neither didst thou tell it me, neither heard I it but only to-day.
+27|And Abraam took sheep and calves, and gave them to Abimelech, and both made a covenant.
+28|And Abraam set seven ewe-lambs by themselves.
+29|And Abimelech said to Abraam, What are these seven ewe-lambs which thou hast set alone?
+30|And Abraam said, Thou shalt receive the seven ewe-lambs of me, that they may be for me as a witness, that I dug this well.
+31|Therefore he named the name of that place, The Well of the Oath, for there they both swore.
+32|And they made a covenant at the well of the oath. And there rose up Abimelech, Ochozath his friend, and Phichol the commander-in-chief of his army, and they returned to the land of the Phylistines.
+33|And Abraam planted a field at the well of the oath, and called there on the name of the Lord, the everlasting God.
+34|And Abraam sojourned in the land of the Phylistines many days.
 
 #22
-1| And it came to pass after these things that God tempted Abraam, and said to him, Abraam, Abraam; and he said, Lo! I <i>am here</i>. 
-2| And he said, Take thy son, the beloved one, whom thou hast loved—Isaac, and go into the high land, and offer him there for a whole-burnt-offering on one of the mountains which I will tell thee of. 
-3| And Abraam rose up in the morning and saddled his ass, and he took with him two servants, and Isaac his son, and having split wood for a whole-burnt-offering, he arose and departed, and came to the place of which God spoke to him, 
-4| on the third day; and Abraam having lifted up his eyes, saw the place afar off. 
-5| And Abraam said to his servants, Sit ye here with the ass, and I and the lad will proceed thus far, and having worshipped we will return to you. 
-6| And Abraam took the wood of the whole-burnt-offering, and laid it on Isaac his son, and he took into his hands both the fire and the knife, and the two went together. 
-7| And Isaac said to Abraam his father, Father. And he said, What is it, son? And he said, Behold the fire and the wood, where is the sheep for a whole-burnt-offering? 
-8| And Abraam said, God will provide himself a sheep for a whole-burnt-offering, <i>my</i> son. And both having gone together, 
-9| came to the place which God spoke of to him; and there Abraam built the altar, and laid the wood on it, and having bound the feet of Isaac his son together, he laid him on the altar upon the wood. 
-10| And Abraam stretched forth his hand to take the knife to slay his son. 
-11| And an angel of the Lord called him out of heaven, and said, Abraam, Abraam. And he said, Behold, I <i>am here</i>. 
-12| And he said, Lay not thine hand upon the child, neither do anything to him, for now I know that thou fearest God, and for my sake thou hast not spared thy beloved son. 
-13| And Abraam lifted up his eyes and beheld, and lo! a ram caught by his horns in a plant of Sabec; and Abraam went and took the ram, and offered him up for a whole-burnt-offering in the place of Isaac his son.  	
-14| And Abraam called the name of that place, The Lord hath seen; that they might say to-day, In the mount the Lord was seen. 
-15| And an angel of the Lord called Abraam the second time out of heaven, saying, 
-16| I have sworn by myself, says the Lord, because thou hast done this thing, and on my account hast not spared thy beloved son, 
-17| surely blessing I will bless thee, and multiplying I will multiply thy seed as the stars of heaven, and as the sand which is by the shore of the sea, and thy seed shall inherit the cities of their enemies. 
-18| And in thy seed shall all the nations of the earth be blessed, because thou hast hearkened to my voice. 
-19| And Abraam returned to his servants, and they arose and went together to the well of the oath; and Abraam dwelt at the well of the oath. 	
-20| And it came to pass after these things, that it was reported to Abraam, saying, Behold, Melcha herself too has born sons to Nachor thy brother, 
-21| Uz the first-born, and Baux his brother, and Camuel the father of the Syrians, and Chazad, and 
-22| Azav and Phaldes, and Jeldaph, and Bathuel, and Bathuel begot Rebecca; 
-23| these are eight sons, which Melcha bore to Nachor the brother of Abraam. 
-24| And his concubine whose name was Rheuma, she also bore Tabec, and Taam, and Tochos, and Mocha. 	3 	
+1|And it came to pass after these things that God tempted Abraam, and said to him, Abraam, Abraam; and he said, Lo! I <i>am here</i>.
+2|And he said, Take thy son, the beloved one, whom thou hast loved—Isaac, and go into the high land, and offer him there for a whole-burnt-offering on one of the mountains which I will tell thee of.
+3|And Abraam rose up in the morning and saddled his ass, and he took with him two servants, and Isaac his son, and having split wood for a whole-burnt-offering, he arose and departed, and came to the place of which God spoke to him,
+4|on the third day; and Abraam having lifted up his eyes, saw the place afar off.
+5|And Abraam said to his servants, Sit ye here with the ass, and I and the lad will proceed thus far, and having worshipped we will return to you.
+6|And Abraam took the wood of the whole-burnt-offering, and laid it on Isaac his son, and he took into his hands both the fire and the knife, and the two went together.
+7|And Isaac said to Abraam his father, Father. And he said, What is it, son? And he said, Behold the fire and the wood, where is the sheep for a whole-burnt-offering?
+8|And Abraam said, God will provide himself a sheep for a whole-burnt-offering, <i>my</i> son. And both having gone together,
+9|came to the place which God spoke of to him; and there Abraam built the altar, and laid the wood on it, and having bound the feet of Isaac his son together, he laid him on the altar upon the wood.
+10|And Abraam stretched forth his hand to take the knife to slay his son.
+11|And an angel of the Lord called him out of heaven, and said, Abraam, Abraam. And he said, Behold, I <i>am here</i>.
+12|And he said, Lay not thine hand upon the child, neither do anything to him, for now I know that thou fearest God, and for my sake thou hast not spared thy beloved son.
+13|And Abraam lifted up his eyes and beheld, and lo! a ram caught by his horns in a plant of Sabec; and Abraam went and took the ram, and offered him up for a whole-burnt-offering in the place of Isaac his son.
+14|And Abraam called the name of that place, The Lord hath seen; that they might say to-day, In the mount the Lord was seen.
+15|And an angel of the Lord called Abraam the second time out of heaven, saying,
+16|I have sworn by myself, says the Lord, because thou hast done this thing, and on my account hast not spared thy beloved son,
+17|surely blessing I will bless thee, and multiplying I will multiply thy seed as the stars of heaven, and as the sand which is by the shore of the sea, and thy seed shall inherit the cities of their enemies.
+18|And in thy seed shall all the nations of the earth be blessed, because thou hast hearkened to my voice.
+19|And Abraam returned to his servants, and they arose and went together to the well of the oath; and Abraam dwelt at the well of the oath.
+20|And it came to pass after these things, that it was reported to Abraam, saying, Behold, Melcha herself too has born sons to Nachor thy brother,
+21|Uz the first-born, and Baux his brother, and Camuel the father of the Syrians, and Chazad, and
+22|Azav and Phaldes, and Jeldaph, and Bathuel, and Bathuel begot Rebecca;
+23|these are eight sons, which Melcha bore to Nachor the brother of Abraam.
+24|And his concubine whose name was Rheuma, she also bore Tabec, and Taam, and Tochos, and Mocha.
 
 #23
-1| And the life of Sarrha was an hundred and twenty-seven years. 
-2| And Sarrha died in the city of Arboc, which is in the valley, this is Chebron in the land of Chanaan; and Abraam came to lament for Sarrha and to mourn. 	
-3| And Abraam stood up from before his dead; and Abraam spoke to the sons of Chet, saying, 
-4| I am a sojourner and a stranger among you, give me therefore possession of a burying-place among you, and I will bury my dead away from me.  	
-5| And the sons of Chet answered to Abraam, saying, Not so, Sir, 
-6| but hear us; thou art in the midst of us a king from God; bury thy dead in our choice sepulchres, for not one of us will by any means withhold his sepulchre from thee, so that thou shouldest not bury thy dead there. 
-7| And Abraam rose up and did obeisance to the people of the land, to the sons of Chet. 
-8| And Abraam spoke to them, saying, If ye have it in your mind that I should bury my dead out of my sight, hearken to me, and speak for me to Ephron the son Saar. 
-9| And let him give me the double cave which he has, which is in a part of his field, let him give it me for the money it is worth for possession of a burying-place among you. 
-10| Now Ephron was sitting in the midst of the children of Chet, and Ephron the Chettite answered Abraam and spoke in the hearing of the sons of Chet, and of all who entered the city, saying, 
-11| Attend to me, my lord, and hear me, I give to thee the field and the cave which is in it; I have given it thee before all my country men; bury thy dead. 
-12| And Abraam did obeisance before the people of the land. 
-13| And he said in the ears of Ephron before the people of the land, Since thou art on my side, hear me; take the price of the field from me, and I will bury my dead there. 
-14| But Ephron answered Abraam, saying, 
-15| Nay, my lord, I have heard indeed, the land <i>is worth</i> four hundred silver didrachms, but what can this be between me and thee? nay, do thou bury thy dead. 
-16| And Abraam hearkened to Ephron, and Abraam rendered to Ephron the money, which he mentioned in the ears of the sons of Chet, four hundred didrachms of silver approved with merchants. 
-17| And the field of Ephron, which was in Double Cave, which is opposite Mambre, the field and the cave, which was in it, and every tree which was in the field, and whatever is in its borders round about, were made sure in its borders round about, were made sure 
-18| to Abraam for a possession, before the sons of Chet, and all that entered into the city. 
-19| After this Abraam buried Sarrha his wife in the Double Cave of the field, which is opposite Mambre, this is Chebron in the land of Chanaan. 
-20| So the field and the cave which was in it were made sure to Abraam for possession of a burying place, by the sons of Chet. 	4 	
+1|And the life of Sarrha was an hundred and twenty-seven years.
+2|And Sarrha died in the city of Arboc, which is in the valley, this is Chebron in the land of Chanaan; and Abraam came to lament for Sarrha and to mourn.
+3|And Abraam stood up from before his dead; and Abraam spoke to the sons of Chet, saying,
+4|I am a sojourner and a stranger among you, give me therefore possession of a burying-place among you, and I will bury my dead away from me.
+5|And the sons of Chet answered to Abraam, saying, Not so, Sir,
+6|but hear us; thou art in the midst of us a king from God; bury thy dead in our choice sepulchres, for not one of us will by any means withhold his sepulchre from thee, so that thou shouldest not bury thy dead there.
+7|And Abraam rose up and did obeisance to the people of the land, to the sons of Chet.
+8|And Abraam spoke to them, saying, If ye have it in your mind that I should bury my dead out of my sight, hearken to me, and speak for me to Ephron the son Saar.
+9|And let him give me the double cave which he has, which is in a part of his field, let him give it me for the money it is worth for possession of a burying-place among you.
+10|Now Ephron was sitting in the midst of the children of Chet, and Ephron the Chettite answered Abraam and spoke in the hearing of the sons of Chet, and of all who entered the city, saying,
+11|Attend to me, my lord, and hear me, I give to thee the field and the cave which is in it; I have given it thee before all my country men; bury thy dead.
+12|And Abraam did obeisance before the people of the land.
+13|And he said in the ears of Ephron before the people of the land, Since thou art on my side, hear me; take the price of the field from me, and I will bury my dead there.
+14|But Ephron answered Abraam, saying,
+15|Nay, my lord, I have heard indeed, the land <i>is worth</i> four hundred silver didrachms, but what can this be between me and thee? nay, do thou bury thy dead.
+16|And Abraam hearkened to Ephron, and Abraam rendered to Ephron the money, which he mentioned in the ears of the sons of Chet, four hundred didrachms of silver approved with merchants.
+17|And the field of Ephron, which was in Double Cave, which is opposite Mambre, the field and the cave, which was in it, and every tree which was in the field, and whatever is in its borders round about, were made sure in its borders round about, were made sure
+18|to Abraam for a possession, before the sons of Chet, and all that entered into the city.
+19|After this Abraam buried Sarrha his wife in the Double Cave of the field, which is opposite Mambre, this is Chebron in the land of Chanaan.
+20|So the field and the cave which was in it were made sure to Abraam for possession of a burying place, by the sons of Chet.
 
 #24
-1| And Abraam was old, advanced in days, and the Lord blessed Abraam in all things.  	
-2| And Abraam said to his servant the elder of his house, who had rule over all his possessions, Put thy hand under my thigh, 
-3| and I will adjure thee by the Lord the God of heaven, and the God of the earth, that thou take not a wife for my son Isaac from the daughters of the Chananites, with whom I dwell, in the midst of them. 
-4| But thou shalt go instead to my country, where I was born, and to my tribe, and thou shalt take from thence a wife for my son Isaac. 
-5| And the servant said to him, Shall I carry back thy son to the land whence thou camest forth, if haply the woman should not be willing to return with me to this land? 
-6| And Abraam said to him, Take heed to thyself that thou carry not my son back thither. 
-7| The Lord the God of heaven, and the God of the earth, who took me out of my father’s house, and out of the land whence I sprang, who spoke to me, and who swore to me, saying, I will give this land to thee and to thy seed, he shall send his angel before thee, and thou shalt take a wife to my son from thence. 
-8| And if the woman should not be willing to come with thee into this land, thou shalt be clear from my oath, only carry not my son thither again. 
-9| And the servant put his hand under the thigh of his master Abraam, and swore to him concerning this matter. 
-10| And the servant took ten camels of his master’s camels, and <i>he took</i> of all the goods of his master with him, and he arose and went into Mesopotamia to the city of Nachor. 
-11| And he rested his camels without the city by the well of water towards evening, when damsels go forth to draw water.  	
-12| And he said, O Lord God of my master Abraam, prosper my way before me to day, and deal mercifully with my master Abraam. 
-13| Lo! I stand by the well of water, and the daughters of them that inhabit the city come forth to draw water. 
-14| And it shall be, the virgin to whomsoever I shall say, Incline thy water-pot, that I may drink, and she shall say, Drink thou, and I will give thy camels drink, until they shall have done drinking—even this one thou hast prepared for thy servant Isaac, and hereby shall I know that thou hast dealt mercifully with my master Abraam.  	
-15| And it came to pass before he had done speaking in his mind, that behold, Rebecca the daughter of Bathuel, the son of Melcha, the wife of Nachor, and <i>the same</i> the brother of Abraam, came forth, having a water-pot on her shoulders. 
-16| And the virgin was very beautiful in appearance, she was a virgin, a man had not known her; and she went down to the well, and filled her water-pot, and came up. 
-17| And the servant ran up to meet her, and said, Give me a little water to drink out of thy pitcher; 
-18| and she said, Drink, Sir; and she hasted, and let down the pitcher upon her arm, and gave him to drink, till he ceased drinking. 
-19| And she said, I will also draw water for thy camels, till they shall all have drunk. 
-20| And she hasted, and emptied the water-pot into the trough, and ran to the well to draw again, and drew water for all the camels. 
-21| And the man took great notice of her, and remained silent to know whether the Lord had made his way prosperous or not. 
-22| And it came to pass when all the camels ceased drinking, that the man took golden ear-rings, each of a drachm weight, and he <i>put</i> two bracelets on her hands, their weight was ten pieces of gold. 
-23| And he asked her, and said, Whose daughter art thou? Tell me if there is room for us to lodge with thy father. 
-24| And she said to him, I am the daughter of Bathuel the son of Melcha, whom she bore to Nachor. 
-25| And she said to him, We have both straw and much provender, and a place for resting. 
-26| And the man being well pleased, worshipped the Lord, 
-27| and said, Blessed be the Lord the God of my master Abraam, who has not suffered his righteousness to fail, nor his truth from my master, and the Lord has brought me prosperously to the house of the brother of my lord. 
-28| And the damsel ran and reported to the house of her mother according to these words. 
-29| And Rebecca had a brother whose name was Laban; and Laban ran out to meet the man, to the well. 
-30| And it came to pass when he saw the ear-rings and the bracelets on the hands of his sister, and when he heard the words of Rebecca his sister, saying, Thus the man spoke to me, that he went to the man, as he stood by the camels at the well. 
-31| And he said to him, Come in hither, thou blessed of the Lord, why standest thou without, whereas I have prepared the house and a place for the camels? 
-32| And the man entered into the house, and unloaded the camels, and gave the camels straw and provender, and water to wash his feet, and the feet of the men that were with him. 
-33| And he set before them loaves to eat; but he said, I will not eat, until I have told my errand. And he said, Speak on.  	
-34| And he said, I am a servant of Abraam; 
-35| and the Lord has blessed my master greatly, and he is exalted, and he has given him sheep, and calves, and silver, and gold, servants and servant-maids, camels, and asses. 
-36| And Sarrha my master’s wife bore one son to my master after he had grown old; and he gave him whatever he had. 
-37| And my master caused me to swear, saying, Thou shalt not take a wife to my son of the daughters of the Chananites, among whom I sojourn in their land. 
-38| But thou shalt go to the house of my father, and to my tribe, and thou shalt take thence a wife for my son. 
-39| And I said to my master, Haply the woman will not go with me. 
-40| And he said to me, The Lord God to whom I have been acceptable in his presence, himself shall send out his angel with thee, and shall prosper thy journey, and thou shalt take a wife for my son of my tribe, and of the house of my father. 
-41| Then shalt thou be clear from my curse, for whensoever thou shalt have come to my tribe, and they shall not give her to thee, then shalt thou be clear from my oath. 
-42| And having come this day to the well, I said, Lord God of my master Abraam, if thou prosperest my journey on which I am now going, 
-43| behold, I stand by the well of water, and the daughters of the men of the city come forth to draw water, and it shall be <i>that</i> the damsel to whom I shall say, Give me a little water to drink out of thy pitcher, 
-44| and she shall say to me, Both drink thou, and I will draw water for thy camels, this <i>shall be</i> the wife whom the Lord has prepared for his own servant Isaac; and hereby shall I know that thou hast wrought mercy with my master Abraam. 
-45| And it came to pass before I had done speaking in my mind, straightway Rebecca came forth, having her pitcher on her shoulders; and she went down to the well, and drew water; and I said to her, Give me to drink. 
-46| And she hasted and let down her pitcher on her arm from her head, and said, Drink thou, and I will give thy camels drink; and I drank, and she gave the camels drink. 
-47| And I asked her, and said, Whose daughter art thou? tell me; and she said, I am daughter of Bathuel the son of Nachor, whom Melcha bore to him; and I put on her the ear-rings, and the bracelets on her hands. 
-48| And being well-pleased I worshipped the Lord, and I blessed the Lord the God of my master Abraam, who has prospered me in a true way, so that I should take the daughter of my master’s brother for his son. 
-49| If then ye <i>will</i> deal mercifully and justly with my lord, <i>tell me</i>, and if not, tell me, that I may turn to the right hand or to the left.  	
-50| And Laban and Bathuel answered and said, This matter has come forth from the Lord, we shall not be able to answer thee bad or good. 
-51| Behold, Rebecca is before thee, take her and go away, and let her be wife to the son of thy master, as the Lord has said. 
-52| And it came to pass when the servant of Abraam heard these words, he bowed himself to the Lord down to the earth. 
-53| And the servant having brought forth jewels of silver and gold and raiment, gave them to Rebecca, and gave gifts to her brother, and to her mother. 
-54| And both he and the men with him ate and drank and went to sleep. And he arose in the morning and said, Send me away, that I may go to my master. 
-55| And her brethren and her mother said, Let the virgin remain with us about ten days, and after that she shall depart. 
-56| But he said to them, Hinder me not, for the Lord has prospered my journey for me; send me away, that I may depart to my master. 
-57| And they said, Let us call the damsel, and enquire at her mouth. 
-58| And they called Rebecca, and said to her, Wilt thou go with this man? and she said, I will go. 
-59| So they sent forth Rebecca their sister, and her goods, and the servant of Abraam, and his attendants. 
-60| And they blessed Rebecca, and said to her, Thou art our sister; become thou thousands of myriads, and let thy seed possess the cities of their enemies. 
-61| And Rebecca rose up and her maidens, and they mounted the camels and went with the man; and the servant having taken up Rebecca, departed. 	
-62| And Isaac went through the wilderness to the well of the vision, and he dwelt in the land toward the south. 
-63| And Isaac went forth into the plain toward evening to meditate; and having lifted up his eyes, he saw camels coming. 
-64| And Rebecca lifted up her eyes, and saw Isaac; and she alighted briskly from the camel, 
-65| and said to the servant, Who is that man that walks in the plain to meet us? And the servant said, This is my master; and she took her veil and covered herself. 
-66| And the servant told Isaac all that he had done. 
-67| And Isaac went into the house of his mother, and took Rebecca, and she became his wife, and he loved her; and Isaac was comforted for Sarrha his mother. 	5 	
+1|And Abraam was old, advanced in days, and the Lord blessed Abraam in all things.
+2|And Abraam said to his servant the elder of his house, who had rule over all his possessions, Put thy hand under my thigh,
+3|and I will adjure thee by the Lord the God of heaven, and the God of the earth, that thou take not a wife for my son Isaac from the daughters of the Chananites, with whom I dwell, in the midst of them.
+4|But thou shalt go instead to my country, where I was born, and to my tribe, and thou shalt take from thence a wife for my son Isaac.
+5|And the servant said to him, Shall I carry back thy son to the land whence thou camest forth, if haply the woman should not be willing to return with me to this land?
+6|And Abraam said to him, Take heed to thyself that thou carry not my son back thither.
+7|The Lord the God of heaven, and the God of the earth, who took me out of my father's house, and out of the land whence I sprang, who spoke to me, and who swore to me, saying, I will give this land to thee and to thy seed, he shall send his angel before thee, and thou shalt take a wife to my son from thence.
+8|And if the woman should not be willing to come with thee into this land, thou shalt be clear from my oath, only carry not my son thither again.
+9|And the servant put his hand under the thigh of his master Abraam, and swore to him concerning this matter.
+10|And the servant took ten camels of his master's camels, and <i>he took</i> of all the goods of his master with him, and he arose and went into Mesopotamia to the city of Nachor.
+11|And he rested his camels without the city by the well of water towards evening, when damsels go forth to draw water.
+12|And he said, O Lord God of my master Abraam, prosper my way before me to day, and deal mercifully with my master Abraam.
+13|Lo! I stand by the well of water, and the daughters of them that inhabit the city come forth to draw water.
+14|And it shall be, the virgin to whomsoever I shall say, Incline thy water-pot, that I may drink, and she shall say, Drink thou, and I will give thy camels drink, until they shall have done drinking—even this one thou hast prepared for thy servant Isaac, and hereby shall I know that thou hast dealt mercifully with my master Abraam.
+15|And it came to pass before he had done speaking in his mind, that behold, Rebecca the daughter of Bathuel, the son of Melcha, the wife of Nachor, and <i>the same</i> the brother of Abraam, came forth, having a water-pot on her shoulders.
+16|And the virgin was very beautiful in appearance, she was a virgin, a man had not known her; and she went down to the well, and filled her water-pot, and came up.
+17|And the servant ran up to meet her, and said, Give me a little water to drink out of thy pitcher;
+18|and she said, Drink, Sir; and she hasted, and let down the pitcher upon her arm, and gave him to drink, till he ceased drinking.
+19|And she said, I will also draw water for thy camels, till they shall all have drunk.
+20|And she hasted, and emptied the water-pot into the trough, and ran to the well to draw again, and drew water for all the camels.
+21|And the man took great notice of her, and remained silent to know whether the Lord had made his way prosperous or not.
+22|And it came to pass when all the camels ceased drinking, that the man took golden ear-rings, each of a drachm weight, and he <i>put</i> two bracelets on her hands, their weight was ten pieces of gold.
+23|And he asked her, and said, Whose daughter art thou? Tell me if there is room for us to lodge with thy father.
+24|And she said to him, I am the daughter of Bathuel the son of Melcha, whom she bore to Nachor.
+25|And she said to him, We have both straw and much provender, and a place for resting.
+26|And the man being well pleased, worshipped the Lord,
+27|and said, Blessed be the Lord the God of my master Abraam, who has not suffered his righteousness to fail, nor his truth from my master, and the Lord has brought me prosperously to the house of the brother of my lord.
+28|And the damsel ran and reported to the house of her mother according to these words.
+29|And Rebecca had a brother whose name was Laban; and Laban ran out to meet the man, to the well.
+30|And it came to pass when he saw the ear-rings and the bracelets on the hands of his sister, and when he heard the words of Rebecca his sister, saying, Thus the man spoke to me, that he went to the man, as he stood by the camels at the well.
+31|And he said to him, Come in hither, thou blessed of the Lord, why standest thou without, whereas I have prepared the house and a place for the camels?
+32|And the man entered into the house, and unloaded the camels, and gave the camels straw and provender, and water to wash his feet, and the feet of the men that were with him.
+33|And he set before them loaves to eat; but he said, I will not eat, until I have told my errand. And he said, Speak on.
+34|And he said, I am a servant of Abraam;
+35|and the Lord has blessed my master greatly, and he is exalted, and he has given him sheep, and calves, and silver, and gold, servants and servant-maids, camels, and asses.
+36|And Sarrha my master's wife bore one son to my master after he had grown old; and he gave him whatever he had.
+37|And my master caused me to swear, saying, Thou shalt not take a wife to my son of the daughters of the Chananites, among whom I sojourn in their land.
+38|But thou shalt go to the house of my father, and to my tribe, and thou shalt take thence a wife for my son.
+39|And I said to my master, Haply the woman will not go with me.
+40|And he said to me, The Lord God to whom I have been acceptable in his presence, himself shall send out his angel with thee, and shall prosper thy journey, and thou shalt take a wife for my son of my tribe, and of the house of my father.
+41|Then shalt thou be clear from my curse, for whensoever thou shalt have come to my tribe, and they shall not give her to thee, then shalt thou be clear from my oath.
+42|And having come this day to the well, I said, Lord God of my master Abraam, if thou prosperest my journey on which I am now going,
+43|behold, I stand by the well of water, and the daughters of the men of the city come forth to draw water, and it shall be <i>that</i> the damsel to whom I shall say, Give me a little water to drink out of thy pitcher,
+44|and she shall say to me, Both drink thou, and I will draw water for thy camels, this <i>shall be</i> the wife whom the Lord has prepared for his own servant Isaac; and hereby shall I know that thou hast wrought mercy with my master Abraam.
+45|And it came to pass before I had done speaking in my mind, straightway Rebecca came forth, having her pitcher on her shoulders; and she went down to the well, and drew water; and I said to her, Give me to drink.
+46|And she hasted and let down her pitcher on her arm from her head, and said, Drink thou, and I will give thy camels drink; and I drank, and she gave the camels drink.
+47|And I asked her, and said, Whose daughter art thou? tell me; and she said, I am daughter of Bathuel the son of Nachor, whom Melcha bore to him; and I put on her the ear-rings, and the bracelets on her hands.
+48|And being well-pleased I worshipped the Lord, and I blessed the Lord the God of my master Abraam, who has prospered me in a true way, so that I should take the daughter of my master's brother for his son.
+49|If then ye <i>will</i> deal mercifully and justly with my lord, <i>tell me</i>, and if not, tell me, that I may turn to the right hand or to the left.
+50|And Laban and Bathuel answered and said, This matter has come forth from the Lord, we shall not be able to answer thee bad or good.
+51|Behold, Rebecca is before thee, take her and go away, and let her be wife to the son of thy master, as the Lord has said.
+52|And it came to pass when the servant of Abraam heard these words, he bowed himself to the Lord down to the earth.
+53|And the servant having brought forth jewels of silver and gold and raiment, gave them to Rebecca, and gave gifts to her brother, and to her mother.
+54|And both he and the men with him ate and drank and went to sleep. And he arose in the morning and said, Send me away, that I may go to my master.
+55|And her brethren and her mother said, Let the virgin remain with us about ten days, and after that she shall depart.
+56|But he said to them, Hinder me not, for the Lord has prospered my journey for me; send me away, that I may depart to my master.
+57|And they said, Let us call the damsel, and enquire at her mouth.
+58|And they called Rebecca, and said to her, Wilt thou go with this man? and she said, I will go.
+59|So they sent forth Rebecca their sister, and her goods, and the servant of Abraam, and his attendants.
+60|And they blessed Rebecca, and said to her, Thou art our sister; become thou thousands of myriads, and let thy seed possess the cities of their enemies.
+61|And Rebecca rose up and her maidens, and they mounted the camels and went with the man; and the servant having taken up Rebecca, departed.
+62|And Isaac went through the wilderness to the well of the vision, and he dwelt in the land toward the south.
+63|And Isaac went forth into the plain toward evening to meditate; and having lifted up his eyes, he saw camels coming.
+64|And Rebecca lifted up her eyes, and saw Isaac; and she alighted briskly from the camel,
+65|and said to the servant, Who is that man that walks in the plain to meet us? And the servant said, This is my master; and she took her veil and covered herself.
+66|And the servant told Isaac all that he had done.
+67|And Isaac went into the house of his mother, and took Rebecca, and she became his wife, and he loved her; and Isaac was comforted for Sarrha his mother.
 
 #25
-1| And Abraam again took a wife, whose name was Chettura. 
-2| And she bore to him Zombran, and Jezan, and Madal, and Madiam, and Jesboc, and Soie. 
-3| And Jezan begot Saba and Dedan. And the sons of Dedan were the Assurians and the Latusians, and Laomim. 
-4| And the sons of Madiam <i>were</i> Gephar and Aphir, and Enoch, and Abeida, and Eldaga; all these were sons of Chettura. 
-5| But Abraam gave all his possessions to Isaac his son. 
-6| But to the sons of his concubines Abraam gave gifts, and he sent them away from his son Isaac, while he was yet living, to the east into the country of the east. 
-7| And these <i>were</i> the years of the days of the life of Abraam as many as he lived, a hundred and seventy-five years. 
-8| And Abraam failing died in a good old age, an old man and full of days, and was added to his people. 
-9| And Isaac and Ismael his sons buried him in the double cave, in the field of Ephron the son of Saar the Chettite, which is over against Mambre: 
-10| <i>even</i> the field and the cave which Abraam bought of the sons of Chet; there they buried Abraam and Sarrha his wife. 
-11| And it came to pass after Abraam was dead, that God blessed Isaac his son, and Isaac dwelt by the well of the vision. 
-12| And these <i>are</i> the generations of Ismael the son of Abraam, whom Agar the Egyptian the hand-maid of Sarrha bore to Abraam. 
-13| And these <i>are</i> the names of the sons of Ismael, according to the names of their generations. The firstborn of Ismael, Nabaioth, and Kedar, and Nabdeel, and Massam, 
-14| and Masma, and Duma, and Masse, 
-15| and Choddan, and Thaeman, and Jetur, and Naphes, and Kedma. 
-16| These <i>are</i> the sons of Ismael, and these are their names in their tents and in their dwellings, twelve princes according to their nations. 
-17| And these <i>are</i> the years of the life of Ismael, a hundred and thirty-seven years; and he failed and died, and was added to his fathers. 
-18| And he dwelt from Evilat to Sur, which is opposite Egypt, until one comes to the Assyrians; he dwelt in the presence of all his brethren. 	
-19| And these <i>are</i> the generations of Isaac the son of Abraam. 
-20| Abraam begot Isaac. And Isaac was forty years old when he took to wife Rebecca, daughter of Bathuel the Syrian, out of Syrian Mesopotamia, sister of Laban the Syrian. 
-21| And Isaac prayed the Lord concerning Rebecca his wife, because she was barren; and the Lord heard him, and his wife Rebecca conceived in her womb. 
-22| And the babes leaped within her; and she said, If it will be so with me, why is this to me? And she went to enquire of the Lord. 
-23| And the Lord said to her, There are two nations in thy womb, and two peoples shall be separated from thy belly, and one people shall excel the other, and the elder shall serve the younger. 
-24| And the days were fulfilled that she should be delivered, and she had twins in her womb. 
-25| And the first came out red, hairy all over like a skin; and she called his name Esau. 
-26| And after this came forth his brother, and his hand took hold of the heel of Esau; and she called his name Jacob. And Isaac was sixty years old when Rebecca bore them. 
-27| And the lads grew, and Esau was a man skilled in hunting, dwelling in the country, and Jacob a simple man, dwelling in a house. 
-28| And Isaac loved Esau, because his venison was his food, but Rebecca loved Jacob. 	
-29| And Jacob cooked pottage, and Esau came from the plain, fainting. 
-30| And Esau said to Jacob, Let me taste of that red pottage, because I am fainting; therefore his name was called Edom. 
-31| And Jacob said to Esau, Sell me this day thy birthright. 
-32| And Esau said, Behold, I am going to die, and for what good does this birthright <i>belong</i> to me? 
-33| And Jacob said to him, Swear to me this day; and he swore to him; and Esau sold his birthright to Jacob. 
-34| And Jacob gave bread to Esau, and pottage of lentiles; and he ate and drank, and he arose and departed; so Esau slighted his birthright. 	6 	
+1|And Abraam again took a wife, whose name was Chettura.
+2|And she bore to him Zombran, and Jezan, and Madal, and Madiam, and Jesboc, and Soie.
+3|And Jezan begot Saba and Dedan. And the sons of Dedan were the Assurians and the Latusians, and Laomim.
+4|And the sons of Madiam <i>were</i> Gephar and Aphir, and Enoch, and Abeida, and Eldaga; all these were sons of Chettura.
+5|But Abraam gave all his possessions to Isaac his son.
+6|But to the sons of his concubines Abraam gave gifts, and he sent them away from his son Isaac, while he was yet living, to the east into the country of the east.
+7|And these <i>were</i> the years of the days of the life of Abraam as many as he lived, a hundred and seventy-five years.
+8|And Abraam failing died in a good old age, an old man and full of days, and was added to his people.
+9|And Isaac and Ismael his sons buried him in the double cave, in the field of Ephron the son of Saar the Chettite, which is over against Mambre:
+10|<i>even</i> the field and the cave which Abraam bought of the sons of Chet; there they buried Abraam and Sarrha his wife.
+11|And it came to pass after Abraam was dead, that God blessed Isaac his son, and Isaac dwelt by the well of the vision.
+12|And these <i>are</i> the generations of Ismael the son of Abraam, whom Agar the Egyptian the hand-maid of Sarrha bore to Abraam.
+13|And these <i>are</i> the names of the sons of Ismael, according to the names of their generations. The firstborn of Ismael, Nabaioth, and Kedar, and Nabdeel, and Massam,
+14|and Masma, and Duma, and Masse,
+15|and Choddan, and Thaeman, and Jetur, and Naphes, and Kedma.
+16|These <i>are</i> the sons of Ismael, and these are their names in their tents and in their dwellings, twelve princes according to their nations.
+17|And these <i>are</i> the years of the life of Ismael, a hundred and thirty-seven years; and he failed and died, and was added to his fathers.
+18|And he dwelt from Evilat to Sur, which is opposite Egypt, until one comes to the Assyrians; he dwelt in the presence of all his brethren.
+19|And these <i>are</i> the generations of Isaac the son of Abraam.
+20|Abraam begot Isaac. And Isaac was forty years old when he took to wife Rebecca, daughter of Bathuel the Syrian, out of Syrian Mesopotamia, sister of Laban the Syrian.
+21|And Isaac prayed the Lord concerning Rebecca his wife, because she was barren; and the Lord heard him, and his wife Rebecca conceived in her womb.
+22|And the babes leaped within her; and she said, If it will be so with me, why is this to me? And she went to enquire of the Lord.
+23|And the Lord said to her, There are two nations in thy womb, and two peoples shall be separated from thy belly, and one people shall excel the other, and the elder shall serve the younger.
+24|And the days were fulfilled that she should be delivered, and she had twins in her womb.
+25|And the first came out red, hairy all over like a skin; and she called his name Esau.
+26|And after this came forth his brother, and his hand took hold of the heel of Esau; and she called his name Jacob. And Isaac was sixty years old when Rebecca bore them.
+27|And the lads grew, and Esau was a man skilled in hunting, dwelling in the country, and Jacob a simple man, dwelling in a house.
+28|And Isaac loved Esau, because his venison was his food, but Rebecca loved Jacob.
+29|And Jacob cooked pottage, and Esau came from the plain, fainting.
+30|And Esau said to Jacob, Let me taste of that red pottage, because I am fainting; therefore his name was called Edom.
+31|And Jacob said to Esau, Sell me this day thy birthright.
+32|And Esau said, Behold, I am going to die, and for what good does this birthright <i>belong</i> to me?
+33|And Jacob said to him, Swear to me this day; and he swore to him; and Esau sold his birthright to Jacob.
+34|And Jacob gave bread to Esau, and pottage of lentiles; and he ate and drank, and he arose and departed; so Esau slighted his birthright.
 
 #26
-1| And there was a famine in the land, besides the former famine, which was in the time of Abraam; and Isaac went to Abimelech the king of the Phylistines to Gerara. 
-2| And the Lord appeared to him and said, Go not down to Egypt, but dwell in the land, which I shall tell thee of. 
-3| And sojourn in this land; and I will be with thee, and bless thee, for I will give to thee and to thy seed all this land; and I will establish my oath which I swore to thy father Abraam. 
-4| And I will multiply thy seed as the stars of heaven; and I will give to thy seed all this land, and all the nations of the earth shall be blest in thy seed. 
-5| Because Abraam thy father hearkened to my voice, and kept my injunctions, and my commandments, and my ordinances, and my statutes. 
-6| And Isaac dwelt in Gerara. 
-7| And the men of the place questioned him concerning Rebecca his wife, and he said, She is my sister, for he feared to say, She is my wife, lest at any time the men of the place should slay him because of Rebecca, because she was fair. 
-8| And he remained there a long time, and Abimelech the king of Gerara leaned to look through the window, and saw Isaac sporting with Rebecca his wife. 
-9| And Abimelech called Isaac, and said to him, Is she then thy wife? why hast thou said, She is my sister? And Isaac said to him, <i>I did so</i>, for I said, Lest at any time I die on her account. 
-10| And Abimelech said to him, Why hast thou done this to us? one of my kindred within a little had lain with thy wife, and thou wouldest have brought <i>a sin of</i> ignorance upon us. 
-11| And Abimelech charged all his people, saying Every man that touches this man and his wife shall be liable to death. 
-12| And Isaac sowed in that land, and he found in that year barley and hundred-fold, and the Lord blessed him. 
-13| And the man was exalted, and advancing he increased, till he became very great. 
-14| And he had cattle of sheep, and cattle of oxen, and many tilled lands, and the Phylistines envied him. 
-15| And all the wells which the servants of his father had dug in the time of his father, the Phylistines stopped them, and filled them with earth. 
-16| And Abimelech said to Isaac, Depart from us, for thou art become much mightier than we. 
-17| And Isaac departed thence, and rested in the valley of Gerara, and dwelt there.  	
-18| And Isaac dug again the wells of water, which the servants of his father Abraam had dug, and the Phylistines had stopped them, after the death of his father Abraam; and he gave them names, according to the names by which his father named them. 
-19| And the servants of Isaac dug in the valley of Gerara, and they found there a well of living water. 
-20| And the shepherds of Gerara strove with the shepherds of Isaac, saying that the water was theirs; and they called the name of the well, Injury, for they injured him. 
-21| And having departed thence he dug another well, and they strove also for that; and he named the name of it, Enmity. 
-22| And he departed thence and dug another well; and they did not strive about that; and he named the name of it, Room, saying, Because now the Lord has made room for us, and has increased us upon the earth.  	
-23| And he went up thence to the well of the oath. 
-24| And the Lord appeared to him in that night, and said, I am the God of Abraam thy father; fear not, for I am with thee, and I will bless thee, and multiply thy seed for the sake of Abraam thy father. 
-25| And he built there an altar, and called on the name of the Lord, and there he pitched his tent, and there the servants of Isaac dug a well in the valley of Gerara. 
-26| And Abimelech came to him from Gerara, and so did Ochozath his friend, and Phichol the commander-in-chief of his army. 
-27| And Isaac said to them, Wherefore have ye come to me? whereas ye hated me, and sent me away from you. 
-28| And they said, We have surely seen that the Lord was with thee, and we said, Let there be an oath between us and thee, and we will make a covenant with thee, 
-29| that thou shalt do no wrong by us, as we have not abhorred thee, and according as we have treated thee well, and have sent thee forth peaceably; and now thou art blessed of the Lord. 
-30| And he made a feast for them, and they ate and drank. 
-31| And they arose in the morning, and swore each to his neighbour; and Isaac sent them forth, and they departed from him in safety. 
-32| And it came to pass in that day, that the servants of Isaac came and told him of the well which they had dug; and they said, We have not found water. 
-33| And he called it, Oath: therefore he called the name of that city, the Well of Oath, until this day. 	
-34| And Esau was forty years old; and he took to wife Judith the daughter of Beoch the Chettite, and Basemath, daughter of Helon the Chettite. 
-35| And they were provoking to Isaac and Rebecca. 	7 	
+1|And there was a famine in the land, besides the former famine, which was in the time of Abraam; and Isaac went to Abimelech the king of the Phylistines to Gerara.
+2|And the Lord appeared to him and said, Go not down to Egypt, but dwell in the land, which I shall tell thee of.
+3|And sojourn in this land; and I will be with thee, and bless thee, for I will give to thee and to thy seed all this land; and I will establish my oath which I swore to thy father Abraam.
+4|And I will multiply thy seed as the stars of heaven; and I will give to thy seed all this land, and all the nations of the earth shall be blest in thy seed.
+5|Because Abraam thy father hearkened to my voice, and kept my injunctions, and my commandments, and my ordinances, and my statutes.
+6|And Isaac dwelt in Gerara.
+7|And the men of the place questioned him concerning Rebecca his wife, and he said, She is my sister, for he feared to say, She is my wife, lest at any time the men of the place should slay him because of Rebecca, because she was fair.
+8|And he remained there a long time, and Abimelech the king of Gerara leaned to look through the window, and saw Isaac sporting with Rebecca his wife.
+9|And Abimelech called Isaac, and said to him, Is she then thy wife? why hast thou said, She is my sister? And Isaac said to him, <i>I did so</i>, for I said, Lest at any time I die on her account.
+10|And Abimelech said to him, Why hast thou done this to us? one of my kindred within a little had lain with thy wife, and thou wouldest have brought <i>a sin of</i> ignorance upon us.
+11|And Abimelech charged all his people, saying Every man that touches this man and his wife shall be liable to death.
+12|And Isaac sowed in that land, and he found in that year barley and hundred-fold, and the Lord blessed him.
+13|And the man was exalted, and advancing he increased, till he became very great.
+14|And he had cattle of sheep, and cattle of oxen, and many tilled lands, and the Phylistines envied him.
+15|And all the wells which the servants of his father had dug in the time of his father, the Phylistines stopped them, and filled them with earth.
+16|And Abimelech said to Isaac, Depart from us, for thou art become much mightier than we.
+17|And Isaac departed thence, and rested in the valley of Gerara, and dwelt there.
+18|And Isaac dug again the wells of water, which the servants of his father Abraam had dug, and the Phylistines had stopped them, after the death of his father Abraam; and he gave them names, according to the names by which his father named them.
+19|And the servants of Isaac dug in the valley of Gerara, and they found there a well of living water.
+20|And the shepherds of Gerara strove with the shepherds of Isaac, saying that the water was theirs; and they called the name of the well, Injury, for they injured him.
+21|And having departed thence he dug another well, and they strove also for that; and he named the name of it, Enmity.
+22|And he departed thence and dug another well; and they did not strive about that; and he named the name of it, Room, saying, Because now the Lord has made room for us, and has increased us upon the earth.
+23|And he went up thence to the well of the oath.
+24|And the Lord appeared to him in that night, and said, I am the God of Abraam thy father; fear not, for I am with thee, and I will bless thee, and multiply thy seed for the sake of Abraam thy father.
+25|And he built there an altar, and called on the name of the Lord, and there he pitched his tent, and there the servants of Isaac dug a well in the valley of Gerara.
+26|And Abimelech came to him from Gerara, and so did Ochozath his friend, and Phichol the commander-in-chief of his army.
+27|And Isaac said to them, Wherefore have ye come to me? whereas ye hated me, and sent me away from you.
+28|And they said, We have surely seen that the Lord was with thee, and we said, Let there be an oath between us and thee, and we will make a covenant with thee,
+29|that thou shalt do no wrong by us, as we have not abhorred thee, and according as we have treated thee well, and have sent thee forth peaceably; and now thou art blessed of the Lord.
+30|And he made a feast for them, and they ate and drank.
+31|And they arose in the morning, and swore each to his neighbour; and Isaac sent them forth, and they departed from him in safety.
+32|And it came to pass in that day, that the servants of Isaac came and told him of the well which they had dug; and they said, We have not found water.
+33|And he called it, Oath: therefore he called the name of that city, the Well of Oath, until this day.
+34|And Esau was forty years old; and he took to wife Judith the daughter of Beoch the Chettite, and Basemath, daughter of Helon the Chettite.
+35|And they were provoking to Isaac and Rebecca.
 
 #27
-1| And it came to pass after Isaac was old, that his eyes were dimmed so that he could not see; and he called Esau, his elder son, and said to him, My son; and he said, Behold, I <i>am here</i>. 
-2| And he said, Behold, I am grown old, and know not the day of my death. 
-3| Now then take the weapons, both thy quiver and thy bow, and go into the plain, and get me venison, 
-4| and make me meats, as I like them, and bring them to me that I may eat, that my soul may bless thee, before I die. 
-5| And Rebecca heard Isaac speaking to Esau his son; and Esau went to the plain to procure venison for his father. 
-6| And Rebecca said to Jacob her younger son, Behold, I heard thy father speaking to Esau thy brother, saying, 
-7| Bring me venison, and prepare me meats, that I may eat and bless thee before the Lord before I die. 
-8| Now then, my son, hearken to me, as I command thee. 
-9| And go to the cattle and take for me thence two kids, tender and good, and I will make them meats for thy father, as he likes. 
-10| And thou shalt bring them in to thy father, and he shall eat, that thy father may bless thee before he dies. 
-11| And Jacob said to his mother Rebecca, Esau my brother is a hairy man, and I a smooth man. 
-12| Peradventure my father may feel me, and I shall be before him as one ill-intentioned, and I shall bring upon me a curse, and not a blessing. 
-13| And his mother said to him, On me be thy curse, son; only hearken to my voice, and go and bring <i>them</i> me. 
-14| So he went and took and brought them to his mother; and his mother made meats, as his father liked <i>them</i>.  	
-15| And Rebecca having taken the fine raiment of her elder son Esau which was with her in the house, put it on Jacob her younger son. 
-16| And she put on his arms the skins of the kids, and on the bare parts of his neck. 
-17| And she gave the meats, and the loaves which she had prepared, into the hands of Jacob her son. 
-18| And he brought <i>them</i> to his father, and said, Father; and he said, Behold I <i>am here</i>; who art thou, son? 
-19| And Jacob said to his father, I, Esau thy first-born, have done as thou toldest me; rise, sit, and eat of my venison, that thy soul may bless me. 
-20| And Isaac said to his son, What is this which thou hast quickly found? And he said, That which the Lord thy God presented before me. 
-21| And Isaac said to Jacob, Draw night to me, and I will feel thee, son, if thou art my son Esau or not. 
-22| And Jacob drew night to his father Isaac, and he felt him, and said, The voice <i>is</i> Jacob’s voice, but the hands <i>are</i> the hands of Esau. 
-23| And he knew him not, for his hands were as the hands of his brother Esau, hairy; and he blessed him, 
-24| and he said, Art thou my son Esau? and he said, I <i>am</i>. 
-25| And he said, Bring hither, and I will eat of thy venison, son, that my soul may bless thee; and he brought <i>it</i> near to him, and he ate, and he brought him wine, and he drank. 
-26| And Isaac his father said to him, Draw nigh to me, and kiss me, son. 
-27| And he drew nigh and kissed him, and smelled the smell of his garments, and blessed him, and said, Behold, the smell of my son is as the smell of an abundant field, which the Lord has blessed. 
-28| And may God give thee of the dew of heaven, and of the fatness of the earth, and abundance of corn and wine. 
-29| And let nations serve thee, and princes bow down to thee, and be thou lord of thy brother, and the sons of thy father shall do thee reverence; accursed is he that curses thee, and blessed is he that blesses thee. 	
-30| And it came to pass after Isaac had ceased blessing his son Jacob, it even came to pass, just when Jacob had gone out from the presence of Isaac his father, that Esau his brother came in from his hunting. 
-31| And he also had made meats and brought them to his father; and he said to his father, Let my father arise and eat of his son’s venison, that thy soul may bless me. 
-32| And Isaac his father said to him, Who art thou? And he said, I am thy first-born son Esau. 
-33| And Isaac was amazed with very great amazement, and said, Who then is it that has procured venison for me and brought it to me? and I have eaten of all before thou camest, and I have blessed him, and he shall be blessed. 
-34| And it came to pass when Esau heard the words of his father Isaac, he cried out with a great and very bitter cry, and said, Bless, I pray thee, me also, father. 
-35| And he said to him, Thy brother has come with subtlety, and taken thy blessing. 
-36| And he said, Rightly was his name called Jacob, for lo! this second time has he supplanted me; he has both taken my birthright, and now he has taken my blessing; and Esau said to his father, Hast thou not left a blessing for me, father? 
-37| And Isaac answered and said to Esau, If I have made him thy lord, and have made all his brethren his servants, and have strengthened him with corn and wine, what then shall I do for thee, son? 
-38| And Esau said to his father, Hast thou <i>only</i> one blessing, father? Bless, I pray thee, me also, father. And Isaac being troubled, Esau cried aloud and wept. 
-39| And Isaac his father answered and said to him, Behold, thy dwelling shall be of the fatness of the earth, and of the dew of heaven from above. 
-40| And thou shalt live by thy sword, and shalt serve thy brother; and there shall be <i>a time</i> when thou shalt break and loosen his yoke from off thy neck. 	
-41| And Esau was angry with Jacob because of the blessing, with which his father blessed him; and Esau said in his mind, Let the days of my father’s mourning draw nigh, that I may slay my brother Jacob. 
-42| And the words of Esau her elder son were reported to Rebecca, and she sent and called Jacob her younger son, and said to him, Behold, Esau thy brother threatens thee to kill thee. 
-43| Now then, my son, hear my voice, and rise and depart quickly into Mesopotamia to Laban my brother into Charran. 
-44| And dwell with him certain days, until thy brother’s anger 
-45| and rage depart from thee, and he forget what thou hast done to him; and I will send and fetch thee thence, lest at any time I should be bereaved of you both in one day. 
-46| And Rebecca said to Isaac, I am weary of my life, because of the daughters of the sons of Chet; if Jacob shall take a wife of the daughters of this land, wherefore should I live? 	8 	
+1|And it came to pass after Isaac was old, that his eyes were dimmed so that he could not see; and he called Esau, his elder son, and said to him, My son; and he said, Behold, I <i>am here</i>.
+2|And he said, Behold, I am grown old, and know not the day of my death.
+3|Now then take the weapons, both thy quiver and thy bow, and go into the plain, and get me venison,
+4|and make me meats, as I like them, and bring them to me that I may eat, that my soul may bless thee, before I die.
+5|And Rebecca heard Isaac speaking to Esau his son; and Esau went to the plain to procure venison for his father.
+6|And Rebecca said to Jacob her younger son, Behold, I heard thy father speaking to Esau thy brother, saying,
+7|Bring me venison, and prepare me meats, that I may eat and bless thee before the Lord before I die.
+8|Now then, my son, hearken to me, as I command thee.
+9|And go to the cattle and take for me thence two kids, tender and good, and I will make them meats for thy father, as he likes.
+10|And thou shalt bring them in to thy father, and he shall eat, that thy father may bless thee before he dies.
+11|And Jacob said to his mother Rebecca, Esau my brother is a hairy man, and I a smooth man.
+12|Peradventure my father may feel me, and I shall be before him as one ill-intentioned, and I shall bring upon me a curse, and not a blessing.
+13|And his mother said to him, On me be thy curse, son; only hearken to my voice, and go and bring <i>them</i> me.
+14|So he went and took and brought them to his mother; and his mother made meats, as his father liked <i>them</i>.
+15|And Rebecca having taken the fine raiment of her elder son Esau which was with her in the house, put it on Jacob her younger son.
+16|And she put on his arms the skins of the kids, and on the bare parts of his neck.
+17|And she gave the meats, and the loaves which she had prepared, into the hands of Jacob her son.
+18|And he brought <i>them</i> to his father, and said, Father; and he said, Behold I <i>am here</i>; who art thou, son?
+19|And Jacob said to his father, I, Esau thy first-born, have done as thou toldest me; rise, sit, and eat of my venison, that thy soul may bless me.
+20|And Isaac said to his son, What is this which thou hast quickly found? And he said, That which the Lord thy God presented before me.
+21|And Isaac said to Jacob, Draw night to me, and I will feel thee, son, if thou art my son Esau or not.
+22|And Jacob drew night to his father Isaac, and he felt him, and said, The voice <i>is</i> Jacob's voice, but the hands <i>are</i> the hands of Esau.
+23|And he knew him not, for his hands were as the hands of his brother Esau, hairy; and he blessed him,
+24|and he said, Art thou my son Esau? and he said, I <i>am</i>.
+25|And he said, Bring hither, and I will eat of thy venison, son, that my soul may bless thee; and he brought <i>it</i> near to him, and he ate, and he brought him wine, and he drank.
+26|And Isaac his father said to him, Draw nigh to me, and kiss me, son.
+27|And he drew nigh and kissed him, and smelled the smell of his garments, and blessed him, and said, Behold, the smell of my son is as the smell of an abundant field, which the Lord has blessed.
+28|And may God give thee of the dew of heaven, and of the fatness of the earth, and abundance of corn and wine.
+29|And let nations serve thee, and princes bow down to thee, and be thou lord of thy brother, and the sons of thy father shall do thee reverence; accursed is he that curses thee, and blessed is he that blesses thee.
+30|And it came to pass after Isaac had ceased blessing his son Jacob, it even came to pass, just when Jacob had gone out from the presence of Isaac his father, that Esau his brother came in from his hunting.
+31|And he also had made meats and brought them to his father; and he said to his father, Let my father arise and eat of his son's venison, that thy soul may bless me.
+32|And Isaac his father said to him, Who art thou? And he said, I am thy first-born son Esau.
+33|And Isaac was amazed with very great amazement, and said, Who then is it that has procured venison for me and brought it to me? and I have eaten of all before thou camest, and I have blessed him, and he shall be blessed.
+34|And it came to pass when Esau heard the words of his father Isaac, he cried out with a great and very bitter cry, and said, Bless, I pray thee, me also, father.
+35|And he said to him, Thy brother has come with subtlety, and taken thy blessing.
+36|And he said, Rightly was his name called Jacob, for lo! this second time has he supplanted me; he has both taken my birthright, and now he has taken my blessing; and Esau said to his father, Hast thou not left a blessing for me, father?
+37|And Isaac answered and said to Esau, If I have made him thy lord, and have made all his brethren his servants, and have strengthened him with corn and wine, what then shall I do for thee, son?
+38|And Esau said to his father, Hast thou <i>only</i> one blessing, father? Bless, I pray thee, me also, father. And Isaac being troubled, Esau cried aloud and wept.
+39|And Isaac his father answered and said to him, Behold, thy dwelling shall be of the fatness of the earth, and of the dew of heaven from above.
+40|And thou shalt live by thy sword, and shalt serve thy brother; and there shall be <i>a time</i> when thou shalt break and loosen his yoke from off thy neck.
+41|And Esau was angry with Jacob because of the blessing, with which his father blessed him; and Esau said in his mind, Let the days of my father's mourning draw nigh, that I may slay my brother Jacob.
+42|And the words of Esau her elder son were reported to Rebecca, and she sent and called Jacob her younger son, and said to him, Behold, Esau thy brother threatens thee to kill thee.
+43|Now then, my son, hear my voice, and rise and depart quickly into Mesopotamia to Laban my brother into Charran.
+44|And dwell with him certain days, until thy brother's anger
+45|and rage depart from thee, and he forget what thou hast done to him; and I will send and fetch thee thence, lest at any time I should be bereaved of you both in one day.
+46|And Rebecca said to Isaac, I am weary of my life, because of the daughters of the sons of Chet; if Jacob shall take a wife of the daughters of this land, wherefore should I live?
 
 #28
-1| And Isaac having called for Jacob, blessed him, and charged him, saying, Thou shalt not take a wife of the daughters of the Chananites. 
-2| Rise and depart quickly into Mesopotamia, to the house of Bathuel the father of thy mother, and take to thyself thence a wife of the daughters of Laban thy mother’s brother. 
-3| And may my God bless thee, and increase thee, and multiply thee, and thou shalt become gatherings of nations. 
-4| And may he give thee the blessing of my father Abraam, even to thee and to thy seed after thee, to inherit the land of thy sojourning, which God gave to Abraam. 
-5| So Isaac sent away Jacob, and he went into Mesopotamia to Laban the son of Bethuel the Syrian, the brother of Rebecca the mother of Jacob and Esau. 	
-6| And Esau saw that Isaac blessed Jacob, and sent him away to Mesopotamia of Syria as he blessed him, to take to himself a wife thence, and <i>that</i> he charged him, saying, Thou shalt not take a wife of the daughters of the Chananites; 
-7| and <i>that</i> Jacob hearkened to his father and his mother, and went to Mesopotamia of Syria. 
-8| And Esau also having seen that the daughters of Chanaan were evil before his father Isaac, 
-9| Esau went to Ismael, and took Maeleth the daughter of Ismael, the son of Abraam, the sister of Nabeoth, a wife in addition to his <i>other</i> wives. 	
-10| And Jacob went forth from the well of the oath, and departed into Charrhan. 
-11| And came to a certain place and slept there, for the sun had gone down; and he took <i>one</i> of the stones of the place, and put it at his head, and lay down to sleep in that place, 
-12| and dreamed, and behold a ladder fixed on the earth, whose top reached to heaven, and the angels of God ascended and descended on it. 
-13| And the Lord stood upon it, and said, I am the God of thy father Abraam, and the God of Isaac; fear not, the land on which thou liest, to thee will I give it, and to thy seed. 
-14| And thy seed shall be as the sand of the earth; and it shall spread abroad to the sea, and the south, and the north, and to the east; and in thee and in thy seed shall all the tribes of the earth be blessed. 
-15| And behold I am with thee to preserve thee continually in all the way wherein thou shalt go; and I will bring thee back to this land; for I will not desert thee, until I have done all that I have said to thee. 
-16| And Jacob awaked out of his sleep, and said, The Lord is in this place, and I knew it not. 
-17| And he was afraid, and said, How fearful is this place! this is none other than the house of God, and this is the gate of heaven. 
-18| And Jacob rose up in the morning, and took the stone he <i>had</i> laid there by his head, and he set it up <i>as</i> a pillar, and poured oil on the top of it. 
-19| And he called the name of that place, the House of God; and the name of the city before was Ulam-luz. 
-20| And Jacob vowed a vow, saying, If the Lord God will be with me, and guard me throughout on this journey, on which I am going, and give me bread to eat, and raiment to put on, 
-21| and bring me back in safety to the house of my father, then shall the Lord be for a God to me. 
-22| And this stone, which I have set up for a pillar, shall be to me a house of God; and of all whatsoever thou shalt give me, I will tithe a tenth for thee. 	9 	
+1|And Isaac having called for Jacob, blessed him, and charged him, saying, Thou shalt not take a wife of the daughters of the Chananites.
+2|Rise and depart quickly into Mesopotamia, to the house of Bathuel the father of thy mother, and take to thyself thence a wife of the daughters of Laban thy mother's brother.
+3|And may my God bless thee, and increase thee, and multiply thee, and thou shalt become gatherings of nations.
+4|And may he give thee the blessing of my father Abraam, even to thee and to thy seed after thee, to inherit the land of thy sojourning, which God gave to Abraam.
+5|So Isaac sent away Jacob, and he went into Mesopotamia to Laban the son of Bethuel the Syrian, the brother of Rebecca the mother of Jacob and Esau.
+6|And Esau saw that Isaac blessed Jacob, and sent him away to Mesopotamia of Syria as he blessed him, to take to himself a wife thence, and <i>that</i> he charged him, saying, Thou shalt not take a wife of the daughters of the Chananites;
+7|and <i>that</i> Jacob hearkened to his father and his mother, and went to Mesopotamia of Syria.
+8|And Esau also having seen that the daughters of Chanaan were evil before his father Isaac,
+9|Esau went to Ismael, and took Maeleth the daughter of Ismael, the son of Abraam, the sister of Nabeoth, a wife in addition to his <i>other</i> wives.
+10|And Jacob went forth from the well of the oath, and departed into Charrhan.
+11|And came to a certain place and slept there, for the sun had gone down; and he took <i>one</i> of the stones of the place, and put it at his head, and lay down to sleep in that place,
+12|and dreamed, and behold a ladder fixed on the earth, whose top reached to heaven, and the angels of God ascended and descended on it.
+13|And the Lord stood upon it, and said, I am the God of thy father Abraam, and the God of Isaac; fear not, the land on which thou liest, to thee will I give it, and to thy seed.
+14|And thy seed shall be as the sand of the earth; and it shall spread abroad to the sea, and the south, and the north, and to the east; and in thee and in thy seed shall all the tribes of the earth be blessed.
+15|And behold I am with thee to preserve thee continually in all the way wherein thou shalt go; and I will bring thee back to this land; for I will not desert thee, until I have done all that I have said to thee.
+16|And Jacob awaked out of his sleep, and said, The Lord is in this place, and I knew it not.
+17|And he was afraid, and said, How fearful is this place! this is none other than the house of God, and this is the gate of heaven.
+18|And Jacob rose up in the morning, and took the stone he <i>had</i> laid there by his head, and he set it up <i>as</i> a pillar, and poured oil on the top of it.
+19|And he called the name of that place, the House of God; and the name of the city before was Ulam-luz.
+20|And Jacob vowed a vow, saying, If the Lord God will be with me, and guard me throughout on this journey, on which I am going, and give me bread to eat, and raiment to put on,
+21|and bring me back in safety to the house of my father, then shall the Lord be for a God to me.
+22|And this stone, which I have set up for a pillar, shall be to me a house of God; and of all whatsoever thou shalt give me, I will tithe a tenth for thee.
 
 #29
-1| And Jacob started and went to the land of the east to Laban, the son of Bathuel the Syrian, and the brother of Rebecca, mother of Jacob and Esau. 
-2| And he looks, and behold! a well in the plain; and there were there three flocks of sheep resting at it, for out of that well they watered the flocks, but there was a great stone at the mouth of the well. 
-3| And there were all the flocks gathered, and they used to roll away the stone from the mouth of the well, and water the flocks, and set the stone again in its place on the mouth of the well. 
-4| And Jacob said to them, Brethren, whence are ye? and they said, We are of Charrhan. 
-5| And he said to them, Know ye Laban, the son of Nachor? and they said, We do know <i>him</i>. 
-6| And he said to them, Is he well? And they said, He is well. And behold Rachel his daughter came with the sheep. 
-7| And Jacob said, it is yet high day, it is not yet time that the flocks be gathered together; water ye the flocks, and depart and feed them. 
-8| And they said, We shall not be able, until all the shepherds be gathered together, and they shall roll away the stone from the mouth of the well, then we will water the flocks. 
-9| While he was yet speaking to them, behold, Rachel the daughter of Laban came with her father’s sheep, for she fed the sheep of her father. 
-10| And it came to pass when Jacob saw Rachel the daughter of Laban, his mother’s brother, and the sheep of Laban, his mother’s brother, that Jacob came and rolled away the stone from the mouth of the well, and watered the sheep of Laban, his mother’s brother. 
-11| And Jacob kissed Rachel, and cried with a loud voice and wept. 
-12| And he told Rachel that he was the near relative of her father, and the son of Rebecca; and she ran and reported to her father according to these words. 
-13| And it came to pass when Laban heard the name of Jacob, his sister’s son, he ran to meet him, and embraced and kissed him, and brought him into his house; and he told Laban all these sayings. 
-14| And Laban said to him, Thou art of my bones and of my flesh; and he was with him a full month. 	
-15| And Laban said to Jacob, Surely thou shalt not serve me for nothing, because thou art my brother; tell me what thy reward is to be. 
-16| Now Laban had two daughters, the name of the elder was Lea, and the name of the younger, Rachel. 
-17| And the eyes of Lea were weak. But Rachel was beautiful in appearance, and exceedingly fair in countenance. 
-18| And Jacob loved Rachel, and said, I will serve thee seven years for thy younger daughter Rachel. 
-19| And Laban said to him, <i>It is</i> better that I should give her to thee, than that I should give her to another man; dwell with me. 
-20| And Jacob served for Rachel seven years, and they were before him as a few days, by reason of his loving her. 
-21| And Jacob said to Laban, Give me my wife, for my days are fulfilled, that I may go in to her. 
-22| And Laban gathered together all the men of the place, and made a marriage-feast. 
-23| And it was even, and he took his daughter Lea, and brought her in to Jacob, and Jacob went in to her. 
-24| And Laban gave to his daughter Lea, Zelpha his handmaid, as a handmaid for her. 
-25| And it was morning, and behold it was Lea; and Jacob said to Laban, What is this that thou hast done to me? did I not serve thee for Rachel? and wherefore hast thou deceived me? 
-26| And Laban answered, It is not done thus in our country, to give the younger before the elder. 
-27| Fulfil then her sevens, and I will give to thee her also in return for thy labour, which thou labourest with me, yet seven other years. 
-28| And Jacob did so, and fulfilled her sevens; and Laban gave him his daughter Rachel to wife. 
-29| And Laban gave to his daughter his handmaid Balla, for a handmaid to her. 
-30| And he went in to Rachel; and he loved Rachel more than Lea; and he served him seven other years. 	
-31| And when the Lord God saw that Lea was hated, he opened her womb; but Rachel was barren. 
-32| And Lea conceived and bore a son to Jacob; and she called his name, Ruben; saying, Because the Lord has looked on my humiliation, and has given me a son, now then my husband will love me. 
-33| And she conceived again, and bore a second son to Jacob; and she said, Because the Lord has heard that I am hated, he has given to me this one also; and she called his name, Simeon. 
-34| And she conceived yet again, and bore a son, and said, In the present time my husband will be with me, for I have born him three sons; therefore she called his name, Levi. 
-35| And having conceived yet again, she bore a son, and said, Now yet again this time will I give thanks to the Lord; therefore she called his name, Juda; and ceased bearing. 	0 	
+1|And Jacob started and went to the land of the east to Laban, the son of Bathuel the Syrian, and the brother of Rebecca, mother of Jacob and Esau.
+2|And he looks, and behold! a well in the plain; and there were there three flocks of sheep resting at it, for out of that well they watered the flocks, but there was a great stone at the mouth of the well.
+3|And there were all the flocks gathered, and they used to roll away the stone from the mouth of the well, and water the flocks, and set the stone again in its place on the mouth of the well.
+4|And Jacob said to them, Brethren, whence are ye? and they said, We are of Charrhan.
+5|And he said to them, Know ye Laban, the son of Nachor? and they said, We do know <i>him</i>.
+6|And he said to them, Is he well? And they said, He is well. And behold Rachel his daughter came with the sheep.
+7|And Jacob said, it is yet high day, it is not yet time that the flocks be gathered together; water ye the flocks, and depart and feed them.
+8|And they said, We shall not be able, until all the shepherds be gathered together, and they shall roll away the stone from the mouth of the well, then we will water the flocks.
+9|While he was yet speaking to them, behold, Rachel the daughter of Laban came with her father's sheep, for she fed the sheep of her father.
+10|And it came to pass when Jacob saw Rachel the daughter of Laban, his mother's brother, and the sheep of Laban, his mother's brother, that Jacob came and rolled away the stone from the mouth of the well, and watered the sheep of Laban, his mother's brother.
+11|And Jacob kissed Rachel, and cried with a loud voice and wept.
+12|And he told Rachel that he was the near relative of her father, and the son of Rebecca; and she ran and reported to her father according to these words.
+13|And it came to pass when Laban heard the name of Jacob, his sister's son, he ran to meet him, and embraced and kissed him, and brought him into his house; and he told Laban all these sayings.
+14|And Laban said to him, Thou art of my bones and of my flesh; and he was with him a full month.
+15|And Laban said to Jacob, Surely thou shalt not serve me for nothing, because thou art my brother; tell me what thy reward is to be.
+16|Now Laban had two daughters, the name of the elder was Lea, and the name of the younger, Rachel.
+17|And the eyes of Lea were weak. But Rachel was beautiful in appearance, and exceedingly fair in countenance.
+18|And Jacob loved Rachel, and said, I will serve thee seven years for thy younger daughter Rachel.
+19|And Laban said to him, <i>It is</i> better that I should give her to thee, than that I should give her to another man; dwell with me.
+20|And Jacob served for Rachel seven years, and they were before him as a few days, by reason of his loving her.
+21|And Jacob said to Laban, Give me my wife, for my days are fulfilled, that I may go in to her.
+22|And Laban gathered together all the men of the place, and made a marriage-feast.
+23|And it was even, and he took his daughter Lea, and brought her in to Jacob, and Jacob went in to her.
+24|And Laban gave to his daughter Lea, Zelpha his handmaid, as a handmaid for her.
+25|And it was morning, and behold it was Lea; and Jacob said to Laban, What is this that thou hast done to me? did I not serve thee for Rachel? and wherefore hast thou deceived me?
+26|And Laban answered, It is not done thus in our country, to give the younger before the elder.
+27|Fulfil then her sevens, and I will give to thee her also in return for thy labour, which thou labourest with me, yet seven other years.
+28|And Jacob did so, and fulfilled her sevens; and Laban gave him his daughter Rachel to wife.
+29|And Laban gave to his daughter his handmaid Balla, for a handmaid to her.
+30|And he went in to Rachel; and he loved Rachel more than Lea; and he served him seven other years.
+31|And when the Lord God saw that Lea was hated, he opened her womb; but Rachel was barren.
+32|And Lea conceived and bore a son to Jacob; and she called his name, Ruben; saying, Because the Lord has looked on my humiliation, and has given me a son, now then my husband will love me.
+33|And she conceived again, and bore a second son to Jacob; and she said, Because the Lord has heard that I am hated, he has given to me this one also; and she called his name, Simeon.
+34|And she conceived yet again, and bore a son, and said, In the present time my husband will be with me, for I have born him three sons; therefore she called his name, Levi.
+35|And having conceived yet again, she bore a son, and said, Now yet again this time will I give thanks to the Lord; therefore she called his name, Juda; and ceased bearing.
 
 #30
-1| And Rachel having perceived that she bore Jacob no children, was jealous of her sister; and said to Jacob, Give me children; and if not, I shall die. 
-2| And Jacob was angry with Rachel, and said to her, Am I in the place of God, who has deprived thee of the fruit of the womb? 
-3| And Rachel said to Jacob, Behold my handmaid Balla, go in to her, and she shall bear upon my knees, and I also shall have children by her. 
-4| And she gave him Balla her maid, for a wife to him; and Jacob went in to her. 
-5| And Balla, Rachel’s maid, conceived, and bore Jacob a son. 
-6| And Rachel said, God has given judgment for me, and hearkened to my voice, and has given me a son; therefore she called his name, Dan. 
-7| And Balla, Rachel’s maid, conceived yet again, and bore a second son to Jacob. 
-8| And Rachel said, God has helped me, and I contended with my sister and prevailed; and she called his name, Nephthalim. 
-9| And Lea saw that she ceased from bearing, and she took Zelpha her maid, and gave her to Jacob for a wife; and he went in to her. 
-10| And Zelpha the maid of Lea conceived, and bore Jacob a son. 
-11| And Lea said, <i>It is</i> happily: and she called his name, Gad. 
-12| And Zelpha the maid of Lea conceived yet again, and bore Jacob a second son. 
-13| And Lea said, I am blessed, for the women will pronounce me blessed; and she called his name, Aser. 
-14| And Ruben went in the day of barley-harvest, and found apples of mandrakes in the field, and brought them to his mother Lea; and Rachel said to Lea her sister, Give me of thy son’s mandrakes. 
-15| And Lea said, <i>Is it</i> not enough for thee that thou hast taken my husband, wilt thou also take my son’s mandrakes? And Rachel said, Not so: let him lie with thee to-night for thy son’s mandrakes. 
-16| And Jacob came in out of the field at even; and Lea went forth to meet him, and said, Thou shalt come in to me this day, for I have hired thee for my son’s mandrakes; and he lay with her that night. 
-17| And God hearkened to Lea, and she conceived, and bore Jacob a fifth son. 
-18| And Lea said, God has given me my reward, because I gave my maid to my husband; and she called his name Issachar, which is, Reward. 
-19| And Lea conceived again, and bore Jacob a sixth son. 
-20| And Lea said, God has given me a good gift in this time; my husband will choose me, for I have born him six sons: and she called his name, Zabulon. 
-21| And after this she bore a daughter; and she called her name, Dina. 
-22| And God remembered Rachel, and God hearkened to her, and he opened her womb. 
-23| And she conceived, and bore Jacob a son; and Rachel said, God has taken away my reproach. 
-24| And she called his name Joseph, saying, Let God add to me another son. 	
-25| And it came to pass when Rachel had born Joseph, Jacob said to Laban, Send me away, that I may go to my place and to my land. 
-26| Restore my wives and my children, for whom I have served thee, that I may depart, for thou knowest the service wherewith I have served thee. 
-27| And Laban said to him, If I have found grace in thy sight, I would augur <i>well</i>, for the Lord has blessed me at thy coming in. 
-28| Appoint me thy wages, and I will give <i>them</i>. 
-29| And Jacob said, Thou knowest in what things I have served thee, and how many cattle of thine are with me. 
-30| For it was little thou hadst before my time, and it is increased to a multitude, and the Lord God has blessed thee since my coming; now then, when shall I set up also my own house? 
-31| And Laban said to him, What shall I give thee? and Jacob said to him, Thou shalt not give me anything; if thou wilt do this thing for me, I will again tend thy flocks and keep them. 
-32| Let all thy sheep pass by to-day, and separate thence every grey sheep among the rams, and every one that is speckled and spotted among the goats—<i>this</i> shall be my reward. 
-33| And my righteousness shall answer for me on the morrow, for it is my reward before thee: whatever shall not be spotted and speckled among the goats, and grey among the rams, shall be stolen with me. 
-34| And Laban said to him, Let it be according to thy word. 
-35| And he separated in that day the spotted and speckled he-goats, and all the spotted and speckled she-goats, and all that was grey among the rams, and every one that was white among them, and he gave them into the hand of his sons. 
-36| And he set a distance of a three days’ journey between them and Jacob. And Jacob tended the cattle of Laban that were left behind. 
-37| And Jacob took to himself green rods of storax tree and walnut and plane-tree; and Jacob peeled in them white stripes; and as he drew off the green, the white stripe which he had made appeared alternate on the rods. 
-38| And he laid the rods which he had peeled, in the hollows of the watering-troughs, that whensoever the cattle should come to drink, as they should have come to drink before the rods, the cattle might conceive at the rods. 
-39| So the cattle conceived at the rods, and the cattle brought forth <i>young</i> speckled, and streaked and spotted with ash-coloured <i>spots</i>. 
-40| And Jacob separated the lambs, and set before the sheep a speckled ram, and every variegated one among the lambs, and he separated flocks for himself alone, and did not mingle them with the sheep of Laban. 
-41| And it came to pass in the time wherein the cattle became pregnant, conceiving in the belly, Jacob put the rods before the cattle in the troughs, that they might conceive by the rods. 
-42| But he did not put them in <i>indiscriminately</i> whenever the cattle happened to bring forth, but the unmarked ones were Laban’s, and the marked ones were Jacob’s. 
-43| And the man became very rich, and he had many cattle, and oxen, and servants, and maid-servants, and camels, and asses. 	1 	
+1|And Rachel having perceived that she bore Jacob no children, was jealous of her sister; and said to Jacob, Give me children; and if not, I shall die.
+2|And Jacob was angry with Rachel, and said to her, Am I in the place of God, who has deprived thee of the fruit of the womb?
+3|And Rachel said to Jacob, Behold my handmaid Balla, go in to her, and she shall bear upon my knees, and I also shall have children by her.
+4|And she gave him Balla her maid, for a wife to him; and Jacob went in to her.
+5|And Balla, Rachel's maid, conceived, and bore Jacob a son.
+6|And Rachel said, God has given judgment for me, and hearkened to my voice, and has given me a son; therefore she called his name, Dan.
+7|And Balla, Rachel's maid, conceived yet again, and bore a second son to Jacob.
+8|And Rachel said, God has helped me, and I contended with my sister and prevailed; and she called his name, Nephthalim.
+9|And Lea saw that she ceased from bearing, and she took Zelpha her maid, and gave her to Jacob for a wife; and he went in to her.
+10|And Zelpha the maid of Lea conceived, and bore Jacob a son.
+11|And Lea said, <i>It is</i> happily: and she called his name, Gad.
+12|And Zelpha the maid of Lea conceived yet again, and bore Jacob a second son.
+13|And Lea said, I am blessed, for the women will pronounce me blessed; and she called his name, Aser.
+14|And Ruben went in the day of barley-harvest, and found apples of mandrakes in the field, and brought them to his mother Lea; and Rachel said to Lea her sister, Give me of thy son's mandrakes.
+15|And Lea said, <i>Is it</i> not enough for thee that thou hast taken my husband, wilt thou also take my son's mandrakes? And Rachel said, Not so: let him lie with thee to-night for thy son's mandrakes.
+16|And Jacob came in out of the field at even; and Lea went forth to meet him, and said, Thou shalt come in to me this day, for I have hired thee for my son's mandrakes; and he lay with her that night.
+17|And God hearkened to Lea, and she conceived, and bore Jacob a fifth son.
+18|And Lea said, God has given me my reward, because I gave my maid to my husband; and she called his name Issachar, which is, Reward.
+19|And Lea conceived again, and bore Jacob a sixth son.
+20|And Lea said, God has given me a good gift in this time; my husband will choose me, for I have born him six sons: and she called his name, Zabulon.
+21|And after this she bore a daughter; and she called her name, Dina.
+22|And God remembered Rachel, and God hearkened to her, and he opened her womb.
+23|And she conceived, and bore Jacob a son; and Rachel said, God has taken away my reproach.
+24|And she called his name Joseph, saying, Let God add to me another son.
+25|And it came to pass when Rachel had born Joseph, Jacob said to Laban, Send me away, that I may go to my place and to my land.
+26|Restore my wives and my children, for whom I have served thee, that I may depart, for thou knowest the service wherewith I have served thee.
+27|And Laban said to him, If I have found grace in thy sight, I would augur <i>well</i>, for the Lord has blessed me at thy coming in.
+28|Appoint me thy wages, and I will give <i>them</i>.
+29|And Jacob said, Thou knowest in what things I have served thee, and how many cattle of thine are with me.
+30|For it was little thou hadst before my time, and it is increased to a multitude, and the Lord God has blessed thee since my coming; now then, when shall I set up also my own house?
+31|And Laban said to him, What shall I give thee? and Jacob said to him, Thou shalt not give me anything; if thou wilt do this thing for me, I will again tend thy flocks and keep them.
+32|Let all thy sheep pass by to-day, and separate thence every grey sheep among the rams, and every one that is speckled and spotted among the goats—<i>this</i> shall be my reward.
+33|And my righteousness shall answer for me on the morrow, for it is my reward before thee: whatever shall not be spotted and speckled among the goats, and grey among the rams, shall be stolen with me.
+34|And Laban said to him, Let it be according to thy word.
+35|And he separated in that day the spotted and speckled he-goats, and all the spotted and speckled she-goats, and all that was grey among the rams, and every one that was white among them, and he gave them into the hand of his sons.
+36|And he set a distance of a three days' journey between them and Jacob. And Jacob tended the cattle of Laban that were left behind.
+37|And Jacob took to himself green rods of storax tree and walnut and plane-tree; and Jacob peeled in them white stripes; and as he drew off the green, the white stripe which he had made appeared alternate on the rods.
+38|And he laid the rods which he had peeled, in the hollows of the watering-troughs, that whensoever the cattle should come to drink, as they should have come to drink before the rods, the cattle might conceive at the rods.
+39|So the cattle conceived at the rods, and the cattle brought forth <i>young</i> speckled, and streaked and spotted with ash-coloured <i>spots</i>.
+40|And Jacob separated the lambs, and set before the sheep a speckled ram, and every variegated one among the lambs, and he separated flocks for himself alone, and did not mingle them with the sheep of Laban.
+41|And it came to pass in the time wherein the cattle became pregnant, conceiving in the belly, Jacob put the rods before the cattle in the troughs, that they might conceive by the rods.
+42|But he did not put them in <i>indiscriminately</i> whenever the cattle happened to bring forth, but the unmarked ones were Laban's, and the marked ones were Jacob's.
+43|And the man became very rich, and he had many cattle, and oxen, and servants, and maid-servants, and camels, and asses.
 
 #31
-1| And Jacob heard the words of the sons of Laban, saying, Jacob has taken all that was our father’s, and of our father’s property has he gotten all this glory. 
-2| And Jacob saw the countenance of Laban, and behold it was not toward him as before. 
-3| And the Lord said to Jacob, Return to the land of thy father, and to thy family, and I will be with thee. 
-4| And Jacob sent and called Lea and Rachel to the plain where the flocks were. 
-5| And he said to them, I see the face of your father, that it is not toward me as before, but the God of my father was with me. 
-6| And ye too know that with all my might I have served your father. 
-7| But your father deceived me, and changed my wages for the ten lambs, yet God gave him not <i>power</i> to hurt me. 
-8| If he should say thus, The speckled shall be thy reward, then all the cattle would bear speckled; and if he should say, The white shall be thy reward, then would all the cattle bear white. 
-9| So God has taken away all the cattle of your father, and given them to me. 
-10| And it came to pass when the cattle conceived and were with young, that I beheld with mine eyes in sleep, and behold the he-goats and the rams leaping on the sheep and the she-goats, speckled and variegated and spotted with ash-coloured spots. 
-11| And the angel of God said to me in a dream, Jacob; and I said, What is it? 
-12| And he said, Look up with thine eyes, and behold the he-goats and the rams leaping on the sheep and the she-goats, speckled and variegated and spotted with ash-coloured spots; for I have seen all things that Laban does to thee. 
-13| I am God that appeared to thee in the place of God where thou anointedst a pillar to me, and vowedst to me there a vow; now then arise and depart out of this land, depart into the land of thy nativity, and I will be with thee. 
-14| And Rachel and Lea answered and said to him, Have we yet a part or inheritance in the house of our father? 
-15| Are we not considered strangers by him? for he has sold us, and quite devoured our money. 
-16| All the wealth and the glory which God has taken from our father, it shall be our’s and our children’s; now then do whatsoever God has said to thee. 
-17| And Jacob arose and took his wives and his children up on the camels; 
-18| and he took away all his possessions and all his store, which he had gotten in Mesopotamia, and all that belonged to him, to depart to Isaac his father in the land of Chanaan. 
-19| And Laban went to shear his sheep; and Rachel stole her father’s images. 
-20| And Jacob hid <i>the matter from</i> Laban the Syrian, so as not to tell him that he ran away. 
-21| And he departed himself and all that belonged to him, and passed over the river, and went into the mountain Galaad. 
-22| But it was told Laban the Syrian on the third day, that Jacob was fled. 
-23| And having taken his brethren with him, he pursued after him seven days’ journey, and overtook him on Mount Galaad. 
-24| And God came to Laban the Syrian in sleep by night, and said to him, Take heed to thyself that thou speak not at any time to Jacob evil things. 
-25| And Laban overtook Jacob; and Jacob pitched his tent in the mountain; and Laban stationed his brothers in the mount Galaad. 
-26| And Laban said to Jacob, What hast thou done? wherefore didst thou run away secretly, and pillage me, and lead away my daughters as captives taken with the sword? 
-27| Whereas if thou hadst told me, I would have sent thee away with mirth, and with songs, and timbrels, and harp. 
-28| And I was not counted worthy to embrace my children and my daughters; now then thou hast wrought foolishly. 
-29| And now my hand has power to hurt thee; but the God of thy father spoke to me yesterday, saying, Take heed to thyself that thou speak not evil words to Jacob. 
-30| Now then go on thy way, for thou hast earnestly desired to depart to the house of thy father; wherefore hast thou stolen my gods? 
-31| And Jacob answered and said to Laban, Because I was afraid; for I said, Lest at any time thou shouldest take away thy daughters from me, and all my possessions. 
-32| And Jacob said, With whomsoever thou shalt find thy gods, he shall not live in the presence of our brethren; take notice of what I have of thy property, and take it; and he observed nothing with him, but Jacob knew not that his wife Rachel had stolen them. 
-33| And Laban went in and searched in the house of Lea, and found <i>them</i> not; and he went out of the house of Lea, and searched in the house of Jacob, and in the house of the two maid-servants, and found them not; and he went also into the house of Rachel. 
-34| And Rachel took the idols, and cast them among the camel’s packs, and sat upon them. 
-35| And she said to her father, Be not indignant, Sir; I cannot rise up before thee, for it is with me according to the manner of women. Laban searched in all the house, and found not the images. 
-36| And Jacob was angry, and strove with Laban; and Jacob answered and said to Laban, What is my injustice, and what my sin, that thou hast pursued after me, 
-37| and that thou hast searched all the furniture of my house? what hast thou found of all the furniture of thine house? set it here between thy relations and my relations, and let them decide between us two. 
-38| These twenty years have I been with thee; thy sheep, and thy she-goats have not failed in bearing; I devoured not the rams of thy cattle. 
-39| That which was taken of beasts I brought not to thee; I made good of myself the thefts of the day, and the thefts of the night. 
-40| I was parched with heat by day, and <i>chilled</i> with frost by night, and my sleep departed from my eyes. 
-41| These twenty years have I been in thy house; I served thee fourteen years for thy two daughters, and six years among thy sheep, and thou didst falsely rate my wages for ten lambs. 
-42| Unless I had the God of my father Abraam, and the fear of Isaac, now thou wouldest have sent me away empty; God saw my humiliation, and the labour of my hands, and rebuked thee yesterday. 	
-43| And Laban answered and said to Jacob, The daughters are my daughters, and the sons my sons, and the cattle are my cattle, and all things which thou seest are mine, and <i>the property</i> of my daughters; what shall I do to them to-day, or their children which they bore? 
-44| Now then come, let me make a covenant, both I and thou, and it shall be for a witness between me and thee; and he said to him, Behold, there is no one with us; behold, God is witness between me and thee. 
-45| And Jacob having taken a stone, set it up for a pillar. 
-46| And Jacob said to his brethren, Gather stones; and they gathered stones and made a heap, and ate there upon the heap; and Laban said to him, This heap witnesses between me and thee to-day. 
-47| And Laban called it, the Heap of Testimony; and Jacob called it, the Witness Heap. 
-48| And Laban said to Jacob, Behold this heap, and the pillar, which I have set between me and thee; this heap witnesses, and this pillar witnesses; therefore its name was called, the Heap witnesses. 
-49| And the vision of which he said—Let God look to it between me and thee, because we are about to depart from each other, — 
-50| If thou shalt humble my daughters, if thou shouldest take wives in addition to my daughters, see, there is no one with us looking on. God <i>is</i> witness between me and thee. 
-51| And Laban said to Jacob, Behold, this heap, and this pillar are a witness. 
-52| For if I should not cross over unto thee, neither shouldest thou cross over to me, for mischief beyond this heap and this pillar. 
-53| The God of Abraam and the God of Nachor judge between us; and Jacob swore by the Fear of his father Isaac. 
-54| And he offered a sacrifice in the mountain, and called his brethren, and they ate and drank, and slept in the mountain. 
-55| And Laban rose up in the morning, and kissed his sons and his daughters, and blessed them; and Laban having turned back, departed to his place. 	2 	
+1|And Jacob heard the words of the sons of Laban, saying, Jacob has taken all that was our father's, and of our father's property has he gotten all this glory.
+2|And Jacob saw the countenance of Laban, and behold it was not toward him as before.
+3|And the Lord said to Jacob, Return to the land of thy father, and to thy family, and I will be with thee.
+4|And Jacob sent and called Lea and Rachel to the plain where the flocks were.
+5|And he said to them, I see the face of your father, that it is not toward me as before, but the God of my father was with me.
+6|And ye too know that with all my might I have served your father.
+7|But your father deceived me, and changed my wages for the ten lambs, yet God gave him not <i>power</i> to hurt me.
+8|If he should say thus, The speckled shall be thy reward, then all the cattle would bear speckled; and if he should say, The white shall be thy reward, then would all the cattle bear white.
+9|So God has taken away all the cattle of your father, and given them to me.
+10|And it came to pass when the cattle conceived and were with young, that I beheld with mine eyes in sleep, and behold the he-goats and the rams leaping on the sheep and the she-goats, speckled and variegated and spotted with ash-coloured spots.
+11|And the angel of God said to me in a dream, Jacob; and I said, What is it?
+12|And he said, Look up with thine eyes, and behold the he-goats and the rams leaping on the sheep and the she-goats, speckled and variegated and spotted with ash-coloured spots; for I have seen all things that Laban does to thee.
+13|I am God that appeared to thee in the place of God where thou anointedst a pillar to me, and vowedst to me there a vow; now then arise and depart out of this land, depart into the land of thy nativity, and I will be with thee.
+14|And Rachel and Lea answered and said to him, Have we yet a part or inheritance in the house of our father?
+15|Are we not considered strangers by him? for he has sold us, and quite devoured our money.
+16|All the wealth and the glory which God has taken from our father, it shall be our's and our children's; now then do whatsoever God has said to thee.
+17|And Jacob arose and took his wives and his children up on the camels;
+18|and he took away all his possessions and all his store, which he had gotten in Mesopotamia, and all that belonged to him, to depart to Isaac his father in the land of Chanaan.
+19|And Laban went to shear his sheep; and Rachel stole her father's images.
+20|And Jacob hid <i>the matter from</i> Laban the Syrian, so as not to tell him that he ran away.
+21|And he departed himself and all that belonged to him, and passed over the river, and went into the mountain Galaad.
+22|But it was told Laban the Syrian on the third day, that Jacob was fled.
+23|And having taken his brethren with him, he pursued after him seven days' journey, and overtook him on Mount Galaad.
+24|And God came to Laban the Syrian in sleep by night, and said to him, Take heed to thyself that thou speak not at any time to Jacob evil things.
+25|And Laban overtook Jacob; and Jacob pitched his tent in the mountain; and Laban stationed his brothers in the mount Galaad.
+26|And Laban said to Jacob, What hast thou done? wherefore didst thou run away secretly, and pillage me, and lead away my daughters as captives taken with the sword?
+27|Whereas if thou hadst told me, I would have sent thee away with mirth, and with songs, and timbrels, and harp.
+28|And I was not counted worthy to embrace my children and my daughters; now then thou hast wrought foolishly.
+29|And now my hand has power to hurt thee; but the God of thy father spoke to me yesterday, saying, Take heed to thyself that thou speak not evil words to Jacob.
+30|Now then go on thy way, for thou hast earnestly desired to depart to the house of thy father; wherefore hast thou stolen my gods?
+31|And Jacob answered and said to Laban, Because I was afraid; for I said, Lest at any time thou shouldest take away thy daughters from me, and all my possessions.
+32|And Jacob said, With whomsoever thou shalt find thy gods, he shall not live in the presence of our brethren; take notice of what I have of thy property, and take it; and he observed nothing with him, but Jacob knew not that his wife Rachel had stolen them.
+33|And Laban went in and searched in the house of Lea, and found <i>them</i> not; and he went out of the house of Lea, and searched in the house of Jacob, and in the house of the two maid-servants, and found them not; and he went also into the house of Rachel.
+34|And Rachel took the idols, and cast them among the camel's packs, and sat upon them.
+35|And she said to her father, Be not indignant, Sir; I cannot rise up before thee, for it is with me according to the manner of women. Laban searched in all the house, and found not the images.
+36|And Jacob was angry, and strove with Laban; and Jacob answered and said to Laban, What is my injustice, and what my sin, that thou hast pursued after me,
+37|and that thou hast searched all the furniture of my house? what hast thou found of all the furniture of thine house? set it here between thy relations and my relations, and let them decide between us two.
+38|These twenty years have I been with thee; thy sheep, and thy she-goats have not failed in bearing; I devoured not the rams of thy cattle.
+39|That which was taken of beasts I brought not to thee; I made good of myself the thefts of the day, and the thefts of the night.
+40|I was parched with heat by day, and <i>chilled</i> with frost by night, and my sleep departed from my eyes.
+41|These twenty years have I been in thy house; I served thee fourteen years for thy two daughters, and six years among thy sheep, and thou didst falsely rate my wages for ten lambs.
+42|Unless I had the God of my father Abraam, and the fear of Isaac, now thou wouldest have sent me away empty; God saw my humiliation, and the labour of my hands, and rebuked thee yesterday.
+43|And Laban answered and said to Jacob, The daughters are my daughters, and the sons my sons, and the cattle are my cattle, and all things which thou seest are mine, and <i>the property</i> of my daughters; what shall I do to them to-day, or their children which they bore?
+44|Now then come, let me make a covenant, both I and thou, and it shall be for a witness between me and thee; and he said to him, Behold, there is no one with us; behold, God is witness between me and thee.
+45|And Jacob having taken a stone, set it up for a pillar.
+46|And Jacob said to his brethren, Gather stones; and they gathered stones and made a heap, and ate there upon the heap; and Laban said to him, This heap witnesses between me and thee to-day.
+47|And Laban called it, the Heap of Testimony; and Jacob called it, the Witness Heap.
+48|And Laban said to Jacob, Behold this heap, and the pillar, which I have set between me and thee; this heap witnesses, and this pillar witnesses; therefore its name was called, the Heap witnesses.
+49|And the vision of which he said—Let God look to it between me and thee, because we are about to depart from each other, —
+50|If thou shalt humble my daughters, if thou shouldest take wives in addition to my daughters, see, there is no one with us looking on. God <i>is</i> witness between me and thee.
+51|And Laban said to Jacob, Behold, this heap, and this pillar are a witness.
+52|For if I should not cross over unto thee, neither shouldest thou cross over to me, for mischief beyond this heap and this pillar.
+53|The God of Abraam and the God of Nachor judge between us; and Jacob swore by the Fear of his father Isaac.
+54|And he offered a sacrifice in the mountain, and called his brethren, and they ate and drank, and slept in the mountain.
+55|And Laban rose up in the morning, and kissed his sons and his daughters, and blessed them; and Laban having turned back, departed to his place.
 
 #32
-1| And Jacob departed for his journey; and having looked up, he saw the host of God encamped; and the angels of God met him. 
-2| And Jacob said, when he saw them, This is the Camp of God; and he called the name of that place, Encampments. 	
-3| And Jacob sent messengers before him to Esau his brother to the land of Seir, to the country of Edom. 
-4| And he charged them, saying, Thus shall ye say to my lord Esau: Thus saith thy servant Jacob; I have sojourned with Laban and tarried until now. 
-5| And there were born to me oxen, and asses, and sheep, and men-servants and women-servants; and I sent to tell my lord Esau, that thy servant might find grace in thy sight. 
-6| And the messengers returned to Jacob, saying, We came to thy brother Esau, and lo! he comes to meet thee, and four hundred men with him. 
-7| And Jacob was greatly terrified, and was perplexed; and he divided the people that was with him, and the cows, and the camels, and the sheep, into two camps. 
-8| And Jacob said, If Esau should come to one camp, and smite it, the other camp shall be in safety. 
-9| And Jacob said, God of my father Abraam, and God of my father Isaac, O Lord, thou <i>art</i> he that said to me, Depart quickly to the land of thy birth, and I will do thee good. 
-10| Let there be to me a sufficiency of all the justice and all the truth which thou hast wrought with thy servant; for with this my staff I passed over this Jordan, and now I am become two camps. 
-11| Deliver me from the hand of my brother, from the hand of Esau, for I am afraid of him, lest haply he should come and smite me, and the mother upon the children. 
-12| But thou saidst, I will do thee good, and will make thy seed as the sand of the sea, which shall not be numbered for multitude. 
-13| And he slept there that night, and took of the gifts which he carried <i>with him</i>, and sent out to Esau his brother, 
-14| two hundred she-goats, twenty he-goats, two hundred sheep, twenty rams, 
-15| milch camels, and their foals, thirty, forty kine, ten bulls, twenty asses, and ten colts. 
-16| And he gave them to his servants <i>each</i> drove apart; and he said to his servants, Go on before me, and put a space between drove and drove. 
-17| And he charged the first, saying, If Esau my brother meet thee, and he ask thee, saying, Whose art thou? and whither wouldest thou go, and whose are these possessions advancing before thee? 
-18| Thou shalt say, Thy servant Jacob’s; he hath sent gifts to my lord Esau, and lo! he is behind us. 
-19| And he charged the first and the second and the third, and all that went before him after these flocks, saying, Thus shall ye speak to Esau when ye find him; 
-20| and ye shall say, Behold thy servant Jacob comes after us. For he said, I will propitiate his countenance with the gifts going before his presence, and afterwards I will behold his face, for peradventure he will accept me. 
-21| So the presents went on before him, but he himself lodged that night in the camp. 
-22| And he rose up in that night, and took his two wives and his two servant-maids, and his eleven children, and crossed over the ford of Jaboch. 
-23| And he took them, and passed over the torrent, and brought over all his possessions. 	
-24| And Jacob was left alone; and a man wrestled with him till the morning. 
-25| And he saw that he prevailed not against him; and he touched the broad part of his thigh, and the broad part of Jacob’s thigh was benumbed in his wrestling with him. 
-26| And he said to him, Let me go, for the day has dawned; but he said, I will not let thee go, except thou bless me. 
-27| And he said to him, What is thy name? and he answered, Jacob. 
-28| And he said to him, Thy name shall no longer be called Jacob, but Israel shall be thy name; for thou hast prevailed with God, and shalt be mighty with men. 
-29| And Jacob asked and said, Tell me thy name; and he said, Wherefore dost thou ask after my name? and he blessed him there. 
-30| And Jacob called the name of that place, the Face of God; for, <i>said he,</i>I have seen God face to face, and my life was preserved. 
-31| And the sun rose upon him, when he passed the Face of God; and he halted upon his thigh. 
-32| Therefore the children of Israel will by no means eat of the sinew which was benumbed, which is on the broad part of the thigh, until this day, because <i>the angel</i> touched the broad part of the thigh of Jacob—<i>even</i> the sinew which was benumbed. 	3 	
+1|And Jacob departed for his journey; and having looked up, he saw the host of God encamped; and the angels of God met him.
+2|And Jacob said, when he saw them, This is the Camp of God; and he called the name of that place, Encampments.
+3|And Jacob sent messengers before him to Esau his brother to the land of Seir, to the country of Edom.
+4|And he charged them, saying, Thus shall ye say to my lord Esau: Thus saith thy servant Jacob; I have sojourned with Laban and tarried until now.
+5|And there were born to me oxen, and asses, and sheep, and men-servants and women-servants; and I sent to tell my lord Esau, that thy servant might find grace in thy sight.
+6|And the messengers returned to Jacob, saying, We came to thy brother Esau, and lo! he comes to meet thee, and four hundred men with him.
+7|And Jacob was greatly terrified, and was perplexed; and he divided the people that was with him, and the cows, and the camels, and the sheep, into two camps.
+8|And Jacob said, If Esau should come to one camp, and smite it, the other camp shall be in safety.
+9|And Jacob said, God of my father Abraam, and God of my father Isaac, O Lord, thou <i>art</i> he that said to me, Depart quickly to the land of thy birth, and I will do thee good.
+10|Let there be to me a sufficiency of all the justice and all the truth which thou hast wrought with thy servant; for with this my staff I passed over this Jordan, and now I am become two camps.
+11|Deliver me from the hand of my brother, from the hand of Esau, for I am afraid of him, lest haply he should come and smite me, and the mother upon the children.
+12|But thou saidst, I will do thee good, and will make thy seed as the sand of the sea, which shall not be numbered for multitude.
+13|And he slept there that night, and took of the gifts which he carried <i>with him</i>, and sent out to Esau his brother,
+14|two hundred she-goats, twenty he-goats, two hundred sheep, twenty rams,
+15|milch camels, and their foals, thirty, forty kine, ten bulls, twenty asses, and ten colts.
+16|And he gave them to his servants <i>each</i> drove apart; and he said to his servants, Go on before me, and put a space between drove and drove.
+17|And he charged the first, saying, If Esau my brother meet thee, and he ask thee, saying, Whose art thou? and whither wouldest thou go, and whose are these possessions advancing before thee?
+18|Thou shalt say, Thy servant Jacob's; he hath sent gifts to my lord Esau, and lo! he is behind us.
+19|And he charged the first and the second and the third, and all that went before him after these flocks, saying, Thus shall ye speak to Esau when ye find him;
+20|and ye shall say, Behold thy servant Jacob comes after us. For he said, I will propitiate his countenance with the gifts going before his presence, and afterwards I will behold his face, for peradventure he will accept me.
+21|So the presents went on before him, but he himself lodged that night in the camp.
+22|And he rose up in that night, and took his two wives and his two servant-maids, and his eleven children, and crossed over the ford of Jaboch.
+23|And he took them, and passed over the torrent, and brought over all his possessions.
+24|And Jacob was left alone; and a man wrestled with him till the morning.
+25|And he saw that he prevailed not against him; and he touched the broad part of his thigh, and the broad part of Jacob's thigh was benumbed in his wrestling with him.
+26|And he said to him, Let me go, for the day has dawned; but he said, I will not let thee go, except thou bless me.
+27|And he said to him, What is thy name? and he answered, Jacob.
+28|And he said to him, Thy name shall no longer be called Jacob, but Israel shall be thy name; for thou hast prevailed with God, and shalt be mighty with men.
+29|And Jacob asked and said, Tell me thy name; and he said, Wherefore dost thou ask after my name? and he blessed him there.
+30|And Jacob called the name of that place, the Face of God; for, <i>said he,</i>I have seen God face to face, and my life was preserved.
+31|And the sun rose upon him, when he passed the Face of God; and he halted upon his thigh.
+32|Therefore the children of Israel will by no means eat of the sinew which was benumbed, which is on the broad part of the thigh, until this day, because <i>the angel</i> touched the broad part of the thigh of Jacob—<i>even</i> the sinew which was benumbed.
 
 #33
-1| And Jacob lifted up his eyes, and beheld, and lo! Esau his brother coming, and four hundred men with him; and Jacob divided the children to Lea and to Rachel, and the two handmaidens. 
-2| And he put the two handmaidens and their children with the first, and Lea and her children behind, and Rachel and Joseph last. 
-3| But he advanced himself before them, and did reverence to the ground seven times, until he drew near to his brother. 
-4| And Esau ran on to meet him, and embraced him, and fell on his neck, and kissed him; and they both wept. 
-5| And Esau looked up and saw the women and the children, and said, What are these to thee? And he said, The children with which God has mercifully blessed thy servant. 
-6| And the maid-servants and their children drew near and did reverence. 
-7| And Lea and her children drew near and did reverence; and after this drew near Rachel and Joseph, and did reverence. 
-8| And he said, What are these things to thee, all these companies that I have met? And he said, That thy servant might find grace in thy sight, my lord. 
-9| And Esau said, I have much, my brother; keep thine own. 
-10| And Jacob said, If I have found grace in thy sight, receive the gifts through my hands; therefore have I seen thy face, as if any one should see the face of God, and thou shalt be well-pleased with me. 
-11| Receive my blessings, which I have brought thee, because God has had mercy on me, and I have all things; and he constrained him, and he took <i>them</i>. 
-12| And he said, Let us depart, and proceed right onward. 
-13| And he said to him, My lord knows, that the children are very tender, and the flocks and the herds with me are with young; if then I shall drive them hard one day, all the cattle will die. 
-14| Let my lord go on before his servant, and I shall have strength on the road according to the ease of the journey before me, and according to the strength of the children, until I come to my lord to Seir. 
-15| And Esau said, I will leave with thee some of the people who are with me. And he said, Why so? it is enough that I have found favour before thee, <i>my</i> lord. 
-16| And Esau returned on that day on his journey to Seir. 
-17| And Jacob departs to his tents; and he made for himself there habitations, and for his cattle he made booths; therefore he called the name of that place, Booths.  	
-18| And Jacob came to Salem, a city of Secima, which is in the land of Chanaan, when he departed out of Mesopotamia of Syria, and took up a position in front of the city. 
-19| And he bought the portion of the field, where he pitched his tent, of Emmor the father of Sychem, for a hundred lambs. 
-20| And he set up there an alter, and called on the God of Israel. 	4 	
+1|And Jacob lifted up his eyes, and beheld, and lo! Esau his brother coming, and four hundred men with him; and Jacob divided the children to Lea and to Rachel, and the two handmaidens.
+2|And he put the two handmaidens and their children with the first, and Lea and her children behind, and Rachel and Joseph last.
+3|But he advanced himself before them, and did reverence to the ground seven times, until he drew near to his brother.
+4|And Esau ran on to meet him, and embraced him, and fell on his neck, and kissed him; and they both wept.
+5|And Esau looked up and saw the women and the children, and said, What are these to thee? And he said, The children with which God has mercifully blessed thy servant.
+6|And the maid-servants and their children drew near and did reverence.
+7|And Lea and her children drew near and did reverence; and after this drew near Rachel and Joseph, and did reverence.
+8|And he said, What are these things to thee, all these companies that I have met? And he said, That thy servant might find grace in thy sight, my lord.
+9|And Esau said, I have much, my brother; keep thine own.
+10|And Jacob said, If I have found grace in thy sight, receive the gifts through my hands; therefore have I seen thy face, as if any one should see the face of God, and thou shalt be well-pleased with me.
+11|Receive my blessings, which I have brought thee, because God has had mercy on me, and I have all things; and he constrained him, and he took <i>them</i>.
+12|And he said, Let us depart, and proceed right onward.
+13|And he said to him, My lord knows, that the children are very tender, and the flocks and the herds with me are with young; if then I shall drive them hard one day, all the cattle will die.
+14|Let my lord go on before his servant, and I shall have strength on the road according to the ease of the journey before me, and according to the strength of the children, until I come to my lord to Seir.
+15|And Esau said, I will leave with thee some of the people who are with me. And he said, Why so? it is enough that I have found favour before thee, <i>my</i> lord.
+16|And Esau returned on that day on his journey to Seir.
+17|And Jacob departs to his tents; and he made for himself there habitations, and for his cattle he made booths; therefore he called the name of that place, Booths.
+18|And Jacob came to Salem, a city of Secima, which is in the land of Chanaan, when he departed out of Mesopotamia of Syria, and took up a position in front of the city.
+19|And he bought the portion of the field, where he pitched his tent, of Emmor the father of Sychem, for a hundred lambs.
+20|And he set up there an alter, and called on the God of Israel.
 
 #34
-1| And Dina, the daughter of Lea, whom she bore to Jacob, went forth to observe the daughters of the inhabitants. 
-2| And Sychem the son of Emmor the Evite, the ruler of the land, saw her, and took her and lay with her, and humbled her. 
-3| And he was attached to the soul of Dina the daughter of Jacob, and he loved the damsel, and he spoke kindly to the damsel. 
-4| Sychem spoke to Emmor his father, saying, Take for me this damsel to wife. 
-5| And Jacob heard that the son of Emmor had defiled Dina his daughter (now his sons were with his cattle in the plain). And Jacob was silent until they came. 
-6| And Emmor the father of Sychem went forth to Jacob, to speak to him. 
-7| And the sons of Jacob came from the plain; and when they heard, the men were deeply pained, and it was very grievous to them, because <i>the man</i> wrought folly in Israel, having lain with the daughter of Jacob, and so it must not be. 
-8| And Emmor spoke to them, saying, Sychem my son has chosen in his heart your daughter; give her therefore to him for a wife, 
-9| and intermarry with us. Give us your daughters, and take our daughters for your sons. 
-10| And dwell in the midst of us; and, behold, the land is spacious before you, dwell in it, and trade, and get possessions in it. 
-11| And Sychem said to her father and to her brothers, I would find grace before you, and we will give whatever ye shall name. 
-12| Multiply <i>your demand of</i> dowry very much, and I will give accordingly as ye shall say to me, only ye shall give me this damsel for a wife.  	
-13| And the sons of Jacob answered to Sychem and Emmor his father craftily, and spoke to them, because they had defiled Dina their sister. 
-14| And Symeon and Levi, the brothers of Dina, said to them, We shall not be able to do this thing, to give our sister to a man who is uncircumcised, for it is a reproach to us. 
-15| Only on these terms will we conform to you, and dwell among you, if ye also will be as we are, in that every male of you be circumcised. 
-16| And we will give our daughters to you, and we will take of your daughters for wives to us, and we will dwell with you, and we will be as one race. 
-17| But if ye will not hearken to us to be circumcised, we will take our daughter and depart. 
-18| And the words pleased Emmor, and Sychem the son of Emmor. 
-19| And the young man delayed not to do this thing, for he was much attached to Jacob’s daughter, and he was the most honourable of all in his father’s house. 
-20| And Emmor and Sychem his son came to the gate of their city, and spoke to the men of their city, saying, 
-21| These men are peaceable, let them dwell with us upon the land, and let them trade in it, and behold the land is extensive before them; we will take their daughters to us for wives, and we will give them our daughters. 
-22| Only on these terms will the men conform to us to dwell with us so as to be one people, if every male of us be circumcised, as they also are circumcised. 
-23| And shall not their cattle and their herds, and their possessions, be ours? only in this let us conform to them, and they will dwell with us. 
-24| And all that went in at the gate of their city hearkened to Emmor and Sychem his son, and they were circumcised in the flesh of their foreskin every male. 	
-25| And it came to pass on the third day, when they were in pain, the two sons of Jacob, Symeon and Levi, Dina’s brethren, took each man his sword, and came upon the city securely, and slew every male. 
-26| And they slew Emmor and Sychem his son with the edge of the sword, and took Dina out of the house of Sychem, and went forth. 
-27| But the sons of Jacob came upon the wounded, and ravaged the city wherein they had defiled Dina their sister. 
-28| And their sheep, and their oxen, and their asses they took, and all things whatsoever were in the city, and whatsoever were in the plain. 
-29| And they took captive all the persons of them, and all their store, and their wives, and plundered both whatever things there were in the city, and whatever things there were in the houses. 
-30| And Jacob said to Symeon and Levi, Ye have made me hateful so that I should be evil to all the inhabitants of the land, both among the Chananites and the Pherezites, and I am few in number; they will gather themselves against me and cut me in pieces, and I shall be utterly destroyed, and my house. 
-31| And they said, Nay, but shall they treat our sister as an harlot? 	5 	
+1|And Dina, the daughter of Lea, whom she bore to Jacob, went forth to observe the daughters of the inhabitants.
+2|And Sychem the son of Emmor the Evite, the ruler of the land, saw her, and took her and lay with her, and humbled her.
+3|And he was attached to the soul of Dina the daughter of Jacob, and he loved the damsel, and he spoke kindly to the damsel.
+4|Sychem spoke to Emmor his father, saying, Take for me this damsel to wife.
+5|And Jacob heard that the son of Emmor had defiled Dina his daughter (now his sons were with his cattle in the plain). And Jacob was silent until they came.
+6|And Emmor the father of Sychem went forth to Jacob, to speak to him.
+7|And the sons of Jacob came from the plain; and when they heard, the men were deeply pained, and it was very grievous to them, because <i>the man</i> wrought folly in Israel, having lain with the daughter of Jacob, and so it must not be.
+8|And Emmor spoke to them, saying, Sychem my son has chosen in his heart your daughter; give her therefore to him for a wife,
+9|and intermarry with us. Give us your daughters, and take our daughters for your sons.
+10|And dwell in the midst of us; and, behold, the land is spacious before you, dwell in it, and trade, and get possessions in it.
+11|And Sychem said to her father and to her brothers, I would find grace before you, and we will give whatever ye shall name.
+12|Multiply <i>your demand of</i> dowry very much, and I will give accordingly as ye shall say to me, only ye shall give me this damsel for a wife.
+13|And the sons of Jacob answered to Sychem and Emmor his father craftily, and spoke to them, because they had defiled Dina their sister.
+14|And Symeon and Levi, the brothers of Dina, said to them, We shall not be able to do this thing, to give our sister to a man who is uncircumcised, for it is a reproach to us.
+15|Only on these terms will we conform to you, and dwell among you, if ye also will be as we are, in that every male of you be circumcised.
+16|And we will give our daughters to you, and we will take of your daughters for wives to us, and we will dwell with you, and we will be as one race.
+17|But if ye will not hearken to us to be circumcised, we will take our daughter and depart.
+18|And the words pleased Emmor, and Sychem the son of Emmor.
+19|And the young man delayed not to do this thing, for he was much attached to Jacob's daughter, and he was the most honourable of all in his father's house.
+20|And Emmor and Sychem his son came to the gate of their city, and spoke to the men of their city, saying,
+21|These men are peaceable, let them dwell with us upon the land, and let them trade in it, and behold the land is extensive before them; we will take their daughters to us for wives, and we will give them our daughters.
+22|Only on these terms will the men conform to us to dwell with us so as to be one people, if every male of us be circumcised, as they also are circumcised.
+23|And shall not their cattle and their herds, and their possessions, be ours? only in this let us conform to them, and they will dwell with us.
+24|And all that went in at the gate of their city hearkened to Emmor and Sychem his son, and they were circumcised in the flesh of their foreskin every male.
+25|And it came to pass on the third day, when they were in pain, the two sons of Jacob, Symeon and Levi, Dina's brethren, took each man his sword, and came upon the city securely, and slew every male.
+26|And they slew Emmor and Sychem his son with the edge of the sword, and took Dina out of the house of Sychem, and went forth.
+27|But the sons of Jacob came upon the wounded, and ravaged the city wherein they had defiled Dina their sister.
+28|And their sheep, and their oxen, and their asses they took, and all things whatsoever were in the city, and whatsoever were in the plain.
+29|And they took captive all the persons of them, and all their store, and their wives, and plundered both whatever things there were in the city, and whatever things there were in the houses.
+30|And Jacob said to Symeon and Levi, Ye have made me hateful so that I should be evil to all the inhabitants of the land, both among the Chananites and the Pherezites, and I am few in number; they will gather themselves against me and cut me in pieces, and I shall be utterly destroyed, and my house.
+31|And they said, Nay, but shall they treat our sister as an harlot?
 
 #35
-1| And God said to Jacob, Arise, go up to the place, Baethel, and dwell there; and make there an altar to the God that appeared to thee, when thou fleddest from the face of Esau thy brother. 
-2| And Jacob said to his house, and to all that were with him, Remove the strange gods that are with you from the midst of you, and purify yourselves, and change your clothes. 
-3| And let us rise and go up to Baethel, and let us there make an alter to God who hearkened to me in the day of calamity, who was with me, and preserved me throughout in the journey, by which I went. 
-4| And they gave to Jacob the strange gods, which were in their hands, and the ear-rings which were in their ears, and Jacob hid them under the turpentine tree which is in Secima, and destroyed them to this day. 
-5| So Israel departed from Secima, and the fear of God was upon the cities round about them, and they did not pursue after the children of Israel.
- 6| And Jacob came to Luza, which is in the land of Chanaan, which is Baethel, he and all the people that were with him. 
-7| And he built there an altar, and called the name of the place Baethel; for there God appeared to him, when he fled from the face of his brother Esau.  	
-8| And Deborrha, Rebecca’s nurse, died, and was buried below Baethel under the oak; and Jacob called its name, The Oak of Mourning. 
-9| And God appeared to Jacob once more in Luza, when he came out of Mesopotamia of Syria, and God blessed him. 
-10| And God said to him, Thy name shall not be called Jacob, but Israel shall be thy name; and he called his name Israel. 
-11| And God said to him, I am thy God; increase and multiply; for nations and gatherings of nations shall be of thee, and kings shall come out of thy loins. 
-12| And the land which I gave to Abraam and Isaac, I have given it to thee; and it shall come to pass that I will give this land also to thy seed after thee. 
-13| And God went up from him from the place where he spoke with him. 
-14| And Jacob set up a pillar in the place where God spoke with him, <i>even</i> a pillar of stone; and offered a libation upon it, and poured oil upon it. 
-15| And Jacob called the name of the place in which God spoke with him, Baethel. 
-16| [[And Jacob removed from Baethel, and pitched his tent beyond the tower of Gader,]]and it came to pass when he drew nigh to Chabratha, to enter into Ephratha, Rachel travailed; and in her travail she was in hard labour. 
-17| And it came to pass in her hard labour, that the midwife said to her, Be of good courage, for thou shalt also have this son. 
-18| And it came to pass in her giving up the ghost (for she was dying), that she called his name, The son of my pain; but his father called his name Benjamin. 
-19| So Rachel died, and was buried in the way of the course of Ephratha, this is Bethleem. 
-20| And Jacob set up a pillar on her tomb; this is the pillar on the tomb of Rachel, until this day. 
-21| And it came to pass when Israel dwelt in that land, that Ruben went and lay with Balla, the concubine of his father Jacob; and Israel heard, and the thing appeared grievous before him.  	
-22|  And the sons of Jacob were twelve. 
-23| The sons of Lea, the first-born of Jacob; Ruben, Symeon, Levi, Judas, Issachar, Zabulon. 
-24| And the sons of Rachel; Joseph and Benjamin. 
-25| And the sons of Balla, the hand-maid of Rachel; Dan and Nephthalim. 
-26| And the sons of Zelpha, the hand-maid of Lea; Gad and Aser. These <i>are</i> the sons of Jacob, which were born to him in Mesopotamia of Syria. 
-27| And Jacob came to Isaac his father to Mambre, to a city of the plain; this is Chebron in the land of Chanaan, where Abraam and Isaac sojourned. 
-28| And the days of Isaac which he lived were an hundred and eighty years. 
-29| And Isaac gave up the ghost and died, and was laid to his family, old and full of days; and Esau and Jacob his sons buried him. 	6 	
+1|And God said to Jacob, Arise, go up to the place, Baethel, and dwell there; and make there an altar to the God that appeared to thee, when thou fleddest from the face of Esau thy brother.
+2|And Jacob said to his house, and to all that were with him, Remove the strange gods that are with you from the midst of you, and purify yourselves, and change your clothes.
+3|And let us rise and go up to Baethel, and let us there make an alter to God who hearkened to me in the day of calamity, who was with me, and preserved me throughout in the journey, by which I went.
+4|And they gave to Jacob the strange gods, which were in their hands, and the ear-rings which were in their ears, and Jacob hid them under the turpentine tree which is in Secima, and destroyed them to this day.
+5|So Israel departed from Secima, and the fear of God was upon the cities round about them, and they did not pursue after the children of Israel.
+6|And Jacob came to Luza, which is in the land of Chanaan, which is Baethel, he and all the people that were with him.
+7|And he built there an altar, and called the name of the place Baethel; for there God appeared to him, when he fled from the face of his brother Esau.
+8|And Deborrha, Rebecca's nurse, died, and was buried below Baethel under the oak; and Jacob called its name, The Oak of Mourning.
+9|And God appeared to Jacob once more in Luza, when he came out of Mesopotamia of Syria, and God blessed him.
+10|And God said to him, Thy name shall not be called Jacob, but Israel shall be thy name; and he called his name Israel.
+11|And God said to him, I am thy God; increase and multiply; for nations and gatherings of nations shall be of thee, and kings shall come out of thy loins.
+12|And the land which I gave to Abraam and Isaac, I have given it to thee; and it shall come to pass that I will give this land also to thy seed after thee.
+13|And God went up from him from the place where he spoke with him.
+14|And Jacob set up a pillar in the place where God spoke with him, <i>even</i> a pillar of stone; and offered a libation upon it, and poured oil upon it.
+15|And Jacob called the name of the place in which God spoke with him, Baethel.
+16|[[And Jacob removed from Baethel, and pitched his tent beyond the tower of Gader,]]and it came to pass when he drew nigh to Chabratha, to enter into Ephratha, Rachel travailed; and in her travail she was in hard labour.
+17|And it came to pass in her hard labour, that the midwife said to her, Be of good courage, for thou shalt also have this son.
+18|And it came to pass in her giving up the ghost (for she was dying), that she called his name, The son of my pain; but his father called his name Benjamin.
+19|So Rachel died, and was buried in the way of the course of Ephratha, this is Bethleem.
+20|And Jacob set up a pillar on her tomb; this is the pillar on the tomb of Rachel, until this day.
+21|And it came to pass when Israel dwelt in that land, that Ruben went and lay with Balla, the concubine of his father Jacob; and Israel heard, and the thing appeared grievous before him.
+22|And the sons of Jacob were twelve.
+23|The sons of Lea, the first-born of Jacob; Ruben, Symeon, Levi, Judas, Issachar, Zabulon.
+24|And the sons of Rachel; Joseph and Benjamin.
+25|And the sons of Balla, the hand-maid of Rachel; Dan and Nephthalim.
+26|And the sons of Zelpha, the hand-maid of Lea; Gad and Aser. These <i>are</i> the sons of Jacob, which were born to him in Mesopotamia of Syria.
+27|And Jacob came to Isaac his father to Mambre, to a city of the plain; this is Chebron in the land of Chanaan, where Abraam and Isaac sojourned.
+28|And the days of Isaac which he lived were an hundred and eighty years.
+29|And Isaac gave up the ghost and died, and was laid to his family, old and full of days; and Esau and Jacob his sons buried him.
 
 #36
-1| And these <i>are</i> the generations of Esau; this is Edom. 
-2| And Esau took to himself wives of the daughters of the Chananites; Ada, the daughter of Ælom the Chettite; and Olibema, daughter of Ana the son of Sebegon, the Evite; 
-3| and Basemath, daughter of Ismael, sister of Nabaioth. 
-4| And Ada bore to him Eliphas; and Basemath bore Raguel. 
-5| And Olibema bore Jeus, and Jeglom, and Core; these <i>are</i> the sons of Esau, which were born to him in the land of Chanaan. 
-6| And Esau took his wives, and his sons, and his daughters, and all the persons of his house, and all his possessions, and all his cattle, and all that he had got, and all things whatsoever he had acquired in the land of Chanaan; and Esau went forth from the land of Chanaan, from the face of his brother Jacob. 
-7| For their substance was too great for them to dwell together; and the land of their sojourning could not bear them, because of the abundance of their possessions. 
-8| And Esau dwelt in mount Seir; Esau, he is Edom. 
-9| And these <i>are</i> the generations of Esau, the father of Edom in the mount Seir. 
-10| And these <i>are</i> the names of the sons of Esau. Eliphas, the son of Ada, the wife of Esau; and Raguel, the son of Basemath, wife of Esau. 
-11| And the sons of Eliphas were Thaeman, Omar, Sophar, Gothom, and Kenez. 
-12| And Thamna was a concubine of Eliphaz, the son of Esau; and she bore Amalec to Eliphas. These <i>are</i> the sons of Ada, the wife of Esau. 
-13| And these <i>are</i> the sons of Raguel; Nachoth, Zare, Some, and Moze. These were the sons of Basemath, wife of Esau. 
-14| And these <i>are</i> the sons of Olibema, the daughter of Ana, the son of Sebegon, the wife of Esau; and she bore to Esau, Jeus, and Jeglom, and Core. 
-15| These <i>are</i> the chiefs of the son of Esau, <i>even</i> the sons of Eliphas, the first-born of Esau; chief Thaeman, chief Omar, chief Sophar, chief Kenez, 
-16| chief Core, chief Gothom, chief Amalec. These <i>are</i> the chiefs of Eliphas, in the land of Edom; these are the sons of Ada. 
-17| And these <i>are</i> the sons of Raguel, the son of Esau; chief Nachoth, chief Zare, chief Some, chief Moze. These <i>are</i> the chiefs of Raguel, in the land of Edom; these are the sons of Basemath, wife of Esau. 
-18| And these <i>are</i> the sons of Olibema, wife of Esau; chief Jeus, chief Jeglom, chief Core. These <i>are</i> the chiefs of Olibema, daughter of Ana, wife of Esau. 
-19| These <i>are</i> the sons of Esau, and these are the chiefs; these are the sons of Edom. 
-20| And these <i>are</i> the sons of Seir, the Chorrhite, who inhabited the land; Lotan, Sobal, Sebegon, Ana, 
-21| and Deson, and Asar, and Rison. These <i>are</i> the chiefs of the Chorrhite, the son of Seir, in the land of Edom. 
-22| And the sons of Lotan <i>were</i> Chorrhi and Haeman; and the sister of Lotan, Thamna. 
-23| And these <i>are</i> the sons of Sobal; Golam, and Manachath, and Gaebel, and Sophar, and Omar. 
-24| And these <i>are</i> the sons of Sebegon; Aie, and Ana; this is the Ana who found Jamin in the wilderness, when he tended the beasts of his father Sebegon. 
-25| And these <i>are</i> the sons of Ana; Deson—and Olibema <i>was</i> daughter of Ana. 
-26| And these <i>are</i> the sons of Deson; Amada, and Asban, and Ithran, and Charrhan. 
-27| And these <i>are</i> the sons of Asar; Balaam, and Zucam, and Jucam. 
-28| And these <i>are</i> the sons of Rison; Hos, and Aran. 
-29| And these <i>are</i> the chiefs of Chorri; chief Lotan, chief Sobal, chief Sebegon, chief Ana, 
-30| chief Deson, chief Asar, chief Rison. These <i>are</i> the chiefs of Chorri, in their principalities in the land of Edom. 	
-31| these <i>are</i> the kings which reigned in Edom, before a king reigned in Israel. 
-32| And Balac, son of Beor, reigned in Edom; and the name of his city <i>was</i> Dennaba. 
-33| And Balac died; and Jobab, son of Zara, from Bosorrha reigned in his stead. 
-34| And Jobab died; and Asom, from the land of the Thaemanites, reigned in his stead. 
-35| And Asom died; and Adad son of Barad, who cut off Madiam in the plain of Moab, ruled in his stead; and the name of his city was Getthaim. 
-36| And Adad died; and Samada of Massecca reigned in his stead. 
-37| Samada died; and Saul of Rhooboth by the river reigned in his stead. 
-38| And Saul died; and Ballenon the son of Achobor reigned in his stead. 
-39| And Ballenon the son of Achobor died; and Arad the son of Barad reigned in his stead; and the name of his city was Phogor; and the name of his wife was Metebeel, daughter of Matraith, son of Maizoob. 
-40| These <i>are</i> the names of the chiefs of Esau, in their tribes, according to their place, in their countries, and in their nations; chief Thamna, chief Gola, chief Jether, 
-41| chief Olibema, chief Helas, chief Phinon, 
-42| chief Kenez, chief Thaeman, chief Mazar, 
-43| chief Magediel, chief Zaphoin. These are the chiefs of Edom in their dwelling-places in the land of their possession; this is Esau, the father of Edom. 	
-44|  And Jacob dwelt in the land where his father sojourned, in the land of Chanaan. 	7 	&nbsp;
+1|And these <i>are</i> the generations of Esau; this is Edom.
+2|And Esau took to himself wives of the daughters of the Chananites; Ada, the daughter of Ælom the Chettite; and Olibema, daughter of Ana the son of Sebegon, the Evite;
+3|and Basemath, daughter of Ismael, sister of Nabaioth.
+4|And Ada bore to him Eliphas; and Basemath bore Raguel.
+5|And Olibema bore Jeus, and Jeglom, and Core; these <i>are</i> the sons of Esau, which were born to him in the land of Chanaan.
+6|And Esau took his wives, and his sons, and his daughters, and all the persons of his house, and all his possessions, and all his cattle, and all that he had got, and all things whatsoever he had acquired in the land of Chanaan; and Esau went forth from the land of Chanaan, from the face of his brother Jacob.
+7|For their substance was too great for them to dwell together; and the land of their sojourning could not bear them, because of the abundance of their possessions.
+8|And Esau dwelt in mount Seir; Esau, he is Edom.
+9|And these <i>are</i> the generations of Esau, the father of Edom in the mount Seir.
+10|And these <i>are</i> the names of the sons of Esau. Eliphas, the son of Ada, the wife of Esau; and Raguel, the son of Basemath, wife of Esau.
+11|And the sons of Eliphas were Thaeman, Omar, Sophar, Gothom, and Kenez.
+12|And Thamna was a concubine of Eliphaz, the son of Esau; and she bore Amalec to Eliphas. These <i>are</i> the sons of Ada, the wife of Esau.
+13|And these <i>are</i> the sons of Raguel; Nachoth, Zare, Some, and Moze. These were the sons of Basemath, wife of Esau.
+14|And these <i>are</i> the sons of Olibema, the daughter of Ana, the son of Sebegon, the wife of Esau; and she bore to Esau, Jeus, and Jeglom, and Core.
+15|These <i>are</i> the chiefs of the son of Esau, <i>even</i> the sons of Eliphas, the first-born of Esau; chief Thaeman, chief Omar, chief Sophar, chief Kenez,
+16|chief Core, chief Gothom, chief Amalec. These <i>are</i> the chiefs of Eliphas, in the land of Edom; these are the sons of Ada.
+17|And these <i>are</i> the sons of Raguel, the son of Esau; chief Nachoth, chief Zare, chief Some, chief Moze. These <i>are</i> the chiefs of Raguel, in the land of Edom; these are the sons of Basemath, wife of Esau.
+18|And these <i>are</i> the sons of Olibema, wife of Esau; chief Jeus, chief Jeglom, chief Core. These <i>are</i> the chiefs of Olibema, daughter of Ana, wife of Esau.
+19|These <i>are</i> the sons of Esau, and these are the chiefs; these are the sons of Edom.
+20|And these <i>are</i> the sons of Seir, the Chorrhite, who inhabited the land; Lotan, Sobal, Sebegon, Ana,
+21|and Deson, and Asar, and Rison. These <i>are</i> the chiefs of the Chorrhite, the son of Seir, in the land of Edom.
+22|And the sons of Lotan <i>were</i> Chorrhi and Haeman; and the sister of Lotan, Thamna.
+23|And these <i>are</i> the sons of Sobal; Golam, and Manachath, and Gaebel, and Sophar, and Omar.
+24|And these <i>are</i> the sons of Sebegon; Aie, and Ana; this is the Ana who found Jamin in the wilderness, when he tended the beasts of his father Sebegon.
+25|And these <i>are</i> the sons of Ana; Deson—and Olibema <i>was</i> daughter of Ana.
+26|And these <i>are</i> the sons of Deson; Amada, and Asban, and Ithran, and Charrhan.
+27|And these <i>are</i> the sons of Asar; Balaam, and Zucam, and Jucam.
+28|And these <i>are</i> the sons of Rison; Hos, and Aran.
+29|And these <i>are</i> the chiefs of Chorri; chief Lotan, chief Sobal, chief Sebegon, chief Ana,
+30|chief Deson, chief Asar, chief Rison. These <i>are</i> the chiefs of Chorri, in their principalities in the land of Edom.
+31|these <i>are</i> the kings which reigned in Edom, before a king reigned in Israel.
+32|And Balac, son of Beor, reigned in Edom; and the name of his city <i>was</i> Dennaba.
+33|And Balac died; and Jobab, son of Zara, from Bosorrha reigned in his stead.
+34|And Jobab died; and Asom, from the land of the Thaemanites, reigned in his stead.
+35|And Asom died; and Adad son of Barad, who cut off Madiam in the plain of Moab, ruled in his stead; and the name of his city was Getthaim.
+36|And Adad died; and Samada of Massecca reigned in his stead.
+37|Samada died; and Saul of Rhooboth by the river reigned in his stead.
+38|And Saul died; and Ballenon the son of Achobor reigned in his stead.
+39|And Ballenon the son of Achobor died; and Arad the son of Barad reigned in his stead; and the name of his city was Phogor; and the name of his wife was Metebeel, daughter of Matraith, son of Maizoob.
+40|These <i>are</i> the names of the chiefs of Esau, in their tribes, according to their place, in their countries, and in their nations; chief Thamna, chief Gola, chief Jether,
+41|chief Olibema, chief Helas, chief Phinon,
+42|chief Kenez, chief Thaeman, chief Mazar,
+43|chief Magediel, chief Zaphoin. These are the chiefs of Edom in their dwelling-places in the land of their possession; this is Esau, the father of Edom.
+44|And Jacob dwelt in the land where his father sojourned, in the land of Chanaan.
 
 #37
-1| And these are the generations of Jacob. And Joseph was seventeen years old, feeding the sheep of his father with his brethren, being young; with the sons of Balla, and with the sons of Zelpha, the wives of his father; and Joseph brought to Israel their father their evil reproach. 
-3| And Jacob loved Joseph more than all his sons, because he was to him the son of old age; and he made for him a coat of many colours. 
-4| And his brethren having seen that his father loved him more than all his sons, hated him, and could not speak anything peaceable to him. 
-5| And Joseph dreamed a dream, and reported it to his brethren. 
-6| And he said to them, Hear this dream which I have dreamed. 
-7| I thought ye were binding sheaves in the middle of the field, and my sheaf stood up and was erected, and your sheaves turned round, and did obeisance to my sheaf. 
-8| And his brethren said to him, Shalt thou indeed reign over us, or shalt thou indeed be lord over us? And they hated him still more for his dreams and for his words. 
-9| And he dreamed another dream, and related it to his father, and to his brethren, and said, Behold, I have dreamed another dream: as it were the sun, and the moon, and the eleven stars did me reverence. 
-10| And his father rebuked him, and said to him, What is this dream which thou hast dreamed? shall indeed both I and thy mother and thy brethren come and bow before thee to the earth? 
-11| And his brethren envied him; but his father observed the saying. 
-12| And his brethren went to feed the sheep of their father to Sychem. 
-13| And Israel said to Joseph, Do not thy brethren feed their flock in Sychem? Come, I will send thee to them; and he said to him, Behold, I <i>am here</i>. 
-14| And Israel said to him, Go and see if thy brethren and the sheep are well, and bring me word; and he sent him out of the valley of Chebron, and he came to Sychem. 
-15| And a man found him wandering in the field; and the man asked him, saying, What seekest thou? 
-16| And he said, I am seeking my brethren; tell me where they feed <i>their flocks</i>. 
-17| And the man said to him, They have departed hence, for I heard them saying, Let us go to Dothaim; and Joseph went after his brethren, and found them in Dothaim.  	
-18| And they spied him from a distance before he drew nigh to them, and they wickedly took counsel to slay him. 
-19| And each said to his brother, Behold, that dreamer comes. 
-20| Now then come, let us kill him, and cast him into one of the pits; and we will say, An evil wild beast has devoured him; and we shall see what his dreams will be. 
-21| And Ruben having heard it, rescued him out of their hands, and said, Let us not kill him. 
-22| And Ruben said to them, Shed not blood; cast him into one of these pits in the wilderness, but do not lay <i>your</i> hands upon him; that he might rescue him out of their hands, and restore him to his father. 
-23| And it came to pass, when Joseph came to his brethren, that they stripped Joseph of his many-coloured coat that was upon him. 
-24| And they took him and cast him into the pit; and the pit was empty, it had not water. 
-25| And they sat down to eat bread; and having lifted up their eyes they beheld, and lo, Ismaelitish travellers came from Galaad, and their camels were heavily loaded with spices, and resin, and myrrh; and they went to bring them to Egypt.  	
-26| And Judas said to his brethren, What profit is it if we slay our brother, and conceal his blood? 
-27| Come, let us sell him to these Ismaelites, but let not our hands be upon him, because he is our brother and our flesh; and his brethren hearkened. 
-28| And the men, the merchants of Madian, went by, and they drew and lifted Joseph out of the pit, and sold Joseph to the Ismaelites for twenty pieces of gold; and they brought Joseph down into Egypt. 
-29| And Ruben returned to the pit, and sees not Joseph in the pit; and he rent his garments. 
-30| And he returned to his brethren and said, The boy is not; and I, whither am I yet to go? 
-31| And having taken the coat of Joseph, they slew a kid of the goats, and stained the coat with the blood. 
-32| And they sent the coat of many colours; and they brought it to their father, and said, This have we found; know if it be thy son’s coat or no. And he recognised it, and said, It is my son’s coat, an evil wild beast has devoured him; a wild beast has carried off Joseph. 
-33| And Jacob rent his clothes, and put sackcloth on his loins, and mourned for his son many days. 
-34|  And all his sons and his daughters gathered themselves together, and came to comfort him; but he would not be comforted, saying, I will go down to my son mourning to Hades; and his father wept for him. 
-35| And the Madianites sold Joseph into Egypt; to Petephres, the eunuch of Pharao, captain of the guard. 	8 	
+1|And these are the generations of Jacob. And Joseph was seventeen years old, feeding the sheep of his father with his brethren, being young; with the sons of Balla, and with the sons of Zelpha, the wives of his father; and Joseph brought to Israel their father their evil reproach.
+3|And Jacob loved Joseph more than all his sons, because he was to him the son of old age; and he made for him a coat of many colours.
+4|And his brethren having seen that his father loved him more than all his sons, hated him, and could not speak anything peaceable to him.
+5|And Joseph dreamed a dream, and reported it to his brethren.
+6|And he said to them, Hear this dream which I have dreamed.
+7|I thought ye were binding sheaves in the middle of the field, and my sheaf stood up and was erected, and your sheaves turned round, and did obeisance to my sheaf.
+8|And his brethren said to him, Shalt thou indeed reign over us, or shalt thou indeed be lord over us? And they hated him still more for his dreams and for his words.
+9|And he dreamed another dream, and related it to his father, and to his brethren, and said, Behold, I have dreamed another dream: as it were the sun, and the moon, and the eleven stars did me reverence.
+10|And his father rebuked him, and said to him, What is this dream which thou hast dreamed? shall indeed both I and thy mother and thy brethren come and bow before thee to the earth?
+11|And his brethren envied him; but his father observed the saying.
+12|And his brethren went to feed the sheep of their father to Sychem.
+13|And Israel said to Joseph, Do not thy brethren feed their flock in Sychem? Come, I will send thee to them; and he said to him, Behold, I <i>am here</i>.
+14|And Israel said to him, Go and see if thy brethren and the sheep are well, and bring me word; and he sent him out of the valley of Chebron, and he came to Sychem.
+15|And a man found him wandering in the field; and the man asked him, saying, What seekest thou?
+16|And he said, I am seeking my brethren; tell me where they feed <i>their flocks</i>.
+17|And the man said to him, They have departed hence, for I heard them saying, Let us go to Dothaim; and Joseph went after his brethren, and found them in Dothaim.
+18|And they spied him from a distance before he drew nigh to them, and they wickedly took counsel to slay him.
+19|And each said to his brother, Behold, that dreamer comes.
+20|Now then come, let us kill him, and cast him into one of the pits; and we will say, An evil wild beast has devoured him; and we shall see what his dreams will be.
+21|And Ruben having heard it, rescued him out of their hands, and said, Let us not kill him.
+22|And Ruben said to them, Shed not blood; cast him into one of these pits in the wilderness, but do not lay <i>your</i> hands upon him; that he might rescue him out of their hands, and restore him to his father.
+23|And it came to pass, when Joseph came to his brethren, that they stripped Joseph of his many-coloured coat that was upon him.
+24|And they took him and cast him into the pit; and the pit was empty, it had not water.
+25|And they sat down to eat bread; and having lifted up their eyes they beheld, and lo, Ismaelitish travellers came from Galaad, and their camels were heavily loaded with spices, and resin, and myrrh; and they went to bring them to Egypt.
+26|And Judas said to his brethren, What profit is it if we slay our brother, and conceal his blood?
+27|Come, let us sell him to these Ismaelites, but let not our hands be upon him, because he is our brother and our flesh; and his brethren hearkened.
+28|And the men, the merchants of Madian, went by, and they drew and lifted Joseph out of the pit, and sold Joseph to the Ismaelites for twenty pieces of gold; and they brought Joseph down into Egypt.
+29|And Ruben returned to the pit, and sees not Joseph in the pit; and he rent his garments.
+30|And he returned to his brethren and said, The boy is not; and I, whither am I yet to go?
+31|And having taken the coat of Joseph, they slew a kid of the goats, and stained the coat with the blood.
+32|And they sent the coat of many colours; and they brought it to their father, and said, This have we found; know if it be thy son's coat or no. And he recognised it, and said, It is my son's coat, an evil wild beast has devoured him; a wild beast has carried off Joseph.
+33|And Jacob rent his clothes, and put sackcloth on his loins, and mourned for his son many days.
+34|And all his sons and his daughters gathered themselves together, and came to comfort him; but he would not be comforted, saying, I will go down to my son mourning to Hades; and his father wept for him.
+35|And the Madianites sold Joseph into Egypt; to Petephres, the eunuch of Pharao, captain of the guard.
 
 #38
-1| And it came to pass at that time that Judas went down from his brethren, and came as far as to a certain man of Odollam, whose name was Iras. 
-2| And Judas saw there the daughter of a Chananitish man, whose name was Sava; and he took her, and went in to her. 
-3| And she conceived and bore a son, and called his name, Er. 
-4| And she conceived and bore a son again; and called his name, Aunan. 
-5| And she again bore a son; and called his name, Selom: and she was in Chasbi when she bore them. 
-6| And Judas took a wife for Er his first-born, whose name was Thamar. 
-7| And Er, the first-born of Judas, was wicked before the Lord; and God killed him. 
-8| And Judas said to Aunan, Go in to thy brother’s wife, and marry her as her brother-in-law, and raise up seed to thy brother. 
-9| And Aunan, knowing that the seed should not be his—it came to pass when he went in to his brother’s wife, that he spilled <i>it</i> upon the ground, so that he should not give seed to his brother’s wife. 
-10| And his doing this appeared evil before God; and he slew him also.  	
-11| And Judas said to Thamar, his daughter-in-law, Sit thou a widow in the house of thy father-in-law, until Selom my son be grown; for he said, lest he also die as his brethren; and Thamar departed, and sat in the house of her father.
- 12| And the days were fulfilled, and Sava the wife of Judas died; and Judas, being comforted, went to them that sheared his sheep, himself and Iras his Shepherd the Odollamite, to Thamna. 
-13| And it was told Thamar his daughter-in-law, saying, Behold, thy father-in-law goeth up to Thamna, to shear his sheep. 
-14| And having taken off the garments of her widowhood from her, she put on a veil, and ornamented her face, and sat by the gates of Ænan, which is in the way to Thamna, for she saw that Selom was grown; but he gave her not to him for a wife. 
-15| And when Judas saw her, he thought her to be a harlot; for she covered her face, and he knew her not. 
-16| And he went out of his way to her, and said to her, Let me come in to thee; for he knew not that she was his daughter-in-law; and she said, What wilt thou give me if thou shouldest come in to me? 
-17| And he said, I will send thee a kid of the goats from my flock; and she said, <i>Well</i>, if thou wilt give me an earnest, until thou send it. 
-18| And he said, What is the earnest that I shall give thee? and she said, Thy ring, and thy bracelet, and the staff in thy hand; and he gave them to her, and went in to her, and she conceived by him. 
-19| And she arose and departed, and took her veil from off her, and put on the garments of her widowhood. 
-20| And Judas sent the kid of the goats by the hand of his shepherd the Odollamite, to receive the pledge from the woman; and he found her not. 
-21| And he asked the men of the place, Where is the harlot who was in Ænan by the way-side? and they said, There was no harlot here. 
-22| And he returned to Judas, and said, I have not found her; and the men of the place say, There is no harlot here. 
-23| And Judas said, Let her have them, but let us not be ridiculed; I sent this kid, but thou hast not found her. 
-24| And it came to pass after three months, that it was told Judas, saying, Thamar thy daughter-in-law has grievously played the harlot, and behold she is with child by whoredom; and Judas said, Bring her out, and let her be burnt. 
-25| And as they were bringing her, she sent to her father-in-law, saying, I am with child by the man whose these things are; and she said, See whose is this ring and bracelet and staff. 
-26| And Judas knew <i>them</i>, and said, Thamar is cleared rather than I, forasmuch as I gave her not to Selom my son: and he knew her not again. 
-27| And it came to pass when she was in labour, that she also had twins in her womb. 
-28| And it came to pass as she was bringing forth, one thrust forth his hand, and the midwife having taken hold of it, bound upon hid hand a scarlet <i>thread</i>, saying, This one shall come out first. 
-29| And when he drew back his hand, then immediately came forth his brother; and she said, Why has the barrier been cut through because of thee? and she called his name, Phares. 
-30| And after this came forth his brother, on whose hand was the scarlet thread; and she called his name, Zara. 	9 	
+1|And it came to pass at that time that Judas went down from his brethren, and came as far as to a certain man of Odollam, whose name was Iras.
+2|And Judas saw there the daughter of a Chananitish man, whose name was Sava; and he took her, and went in to her.
+3|And she conceived and bore a son, and called his name, Er.
+4|And she conceived and bore a son again; and called his name, Aunan.
+5|And she again bore a son; and called his name, Selom: and she was in Chasbi when she bore them.
+6|And Judas took a wife for Er his first-born, whose name was Thamar.
+7|And Er, the first-born of Judas, was wicked before the Lord; and God killed him.
+8|And Judas said to Aunan, Go in to thy brother's wife, and marry her as her brother-in-law, and raise up seed to thy brother.
+9|And Aunan, knowing that the seed should not be his—it came to pass when he went in to his brother's wife, that he spilled <i>it</i> upon the ground, so that he should not give seed to his brother's wife.
+10|And his doing this appeared evil before God; and he slew him also.
+11|And Judas said to Thamar, his daughter-in-law, Sit thou a widow in the house of thy father-in-law, until Selom my son be grown; for he said, lest he also die as his brethren; and Thamar departed, and sat in the house of her father.
+12|And the days were fulfilled, and Sava the wife of Judas died; and Judas, being comforted, went to them that sheared his sheep, himself and Iras his Shepherd the Odollamite, to Thamna.
+13|And it was told Thamar his daughter-in-law, saying, Behold, thy father-in-law goeth up to Thamna, to shear his sheep.
+14|And having taken off the garments of her widowhood from her, she put on a veil, and ornamented her face, and sat by the gates of Ænan, which is in the way to Thamna, for she saw that Selom was grown; but he gave her not to him for a wife.
+15|And when Judas saw her, he thought her to be a harlot; for she covered her face, and he knew her not.
+16|And he went out of his way to her, and said to her, Let me come in to thee; for he knew not that she was his daughter-in-law; and she said, What wilt thou give me if thou shouldest come in to me?
+17|And he said, I will send thee a kid of the goats from my flock; and she said, <i>Well</i>, if thou wilt give me an earnest, until thou send it.
+18|And he said, What is the earnest that I shall give thee? and she said, Thy ring, and thy bracelet, and the staff in thy hand; and he gave them to her, and went in to her, and she conceived by him.
+19|And she arose and departed, and took her veil from off her, and put on the garments of her widowhood.
+20|And Judas sent the kid of the goats by the hand of his shepherd the Odollamite, to receive the pledge from the woman; and he found her not.
+21|And he asked the men of the place, Where is the harlot who was in Ænan by the way-side? and they said, There was no harlot here.
+22|And he returned to Judas, and said, I have not found her; and the men of the place say, There is no harlot here.
+23|And Judas said, Let her have them, but let us not be ridiculed; I sent this kid, but thou hast not found her.
+24|And it came to pass after three months, that it was told Judas, saying, Thamar thy daughter-in-law has grievously played the harlot, and behold she is with child by whoredom; and Judas said, Bring her out, and let her be burnt.
+25|And as they were bringing her, she sent to her father-in-law, saying, I am with child by the man whose these things are; and she said, See whose is this ring and bracelet and staff.
+26|And Judas knew <i>them</i>, and said, Thamar is cleared rather than I, forasmuch as I gave her not to Selom my son: and he knew her not again.
+27|And it came to pass when she was in labour, that she also had twins in her womb.
+28|And it came to pass as she was bringing forth, one thrust forth his hand, and the midwife having taken hold of it, bound upon hid hand a scarlet <i>thread</i>, saying, This one shall come out first.
+29|And when he drew back his hand, then immediately came forth his brother; and she said, Why has the barrier been cut through because of thee? and she called his name, Phares.
+30|And after this came forth his brother, on whose hand was the scarlet thread; and she called his name, Zara.
 
 #39
-1| And Joseph was brought down to Egypt; and Petephres the eunuch of Pharao, the captain of the guard, an Egyptian, bought him of the hands of the Ismaelites, who brought him down thither. 
-2| And the Lord was with Joseph, and he was a prosperous man; and he was in the house with his lord the Egyptian. 
-3| And his master knew that the Lord was with him, and the Lord prospers in his hands whatsoever he happens to do. 
-4| And Joseph found grace in the presence of his lord, and was well-pleasing to him; and he set him over his house, and all that he had he gave into the hand of Joseph. 
-5| And it came to pass after that he was set over his house, and over all that he had, that the Lord blessed the house of the Egyptian for Joseph’s sake; and the blessing of the Lord was on all his possessions in the house, and in his field. 
-6| And he committed all that he had into the hands of Joseph; and he knew not of anything that belonged to him, save the bread which he himself ate. And Joseph was handsome in form, and exceedingly beautiful in countenance. 
-7| And it came to pass after these things, that his master’s wife cast her eyes upon Joseph, and said, Lie with me. 
-8| But he would not; but said to his master’s wife, If because of me my master knows nothing in his house, and has given into my hands all things that belong to him: 
-9| and in this house there is nothing above me, nor has anything been kept back from me, but thou, because thou art his wife—how then shall I do this wicked thing, and sin against God? 
-10| And when she talked with Joseph day by day, and he hearkened not to her to sleep with her, so as to be with her, 
-11| it came to pass on a certain day, that Joseph went into the house to do his business, and there was no one of the household within. 
-12| And she caught hold of him by his clothes, and said, Lie with me; and having left his clothes in her hands, he fled, and went forth. 
-13| And it came to pass, when she saw that he had left his clothes in her hands, and fled, and gone forth, 
-14| that she called those that were in the house, and spoke to them, saying, See, he has brought in to us a Hebrew servant to mock us—he came in to me, saying, Lie with me, and I cried with a loud voice. 
-15| And when he heard that I lifted up my voice and cried, having left his clothes with me, he fled, and went forth out. 
-16| So she leaves the clothes by her, until the master came to his house. 
-17| And she spoke to him according to these words, saying, The Hebrew servant, whom thou broughtest in to us, came in to me to mock me, and said to me, I will lie with thee. 
-18| And when he heard that I lifted up my voice and cried, having left his clothes with me, he fled and departed forth. 
-19| And it came to pass, when his master heard all the words of his wife, that she spoke to him, saying, Thus did thy servant to me, that he was very angry.  	
-20| And his master took Joseph, and cast him into the prison, into the place where the king’s prisoners are kept, there in the prison. 
-21| And the Lord was with Joseph, and poured down mercy upon him; and he gave him favour in the sight of the chief keeper of the prison. 
-22| And the chief keeper of the prison gave the prison into the hand of Joseph, and all the prisoners as many as were in the prison; and all things whatsoever they do there, he did them. 
-23| Because of him the chief keeper of the prison knew nothing, for all things were in the hand of Joseph, because the Lord was with him; and whatever things he did, the Lord made them to prosper in his hands. 	0 	
+1|And Joseph was brought down to Egypt; and Petephres the eunuch of Pharao, the captain of the guard, an Egyptian, bought him of the hands of the Ismaelites, who brought him down thither.
+2|And the Lord was with Joseph, and he was a prosperous man; and he was in the house with his lord the Egyptian.
+3|And his master knew that the Lord was with him, and the Lord prospers in his hands whatsoever he happens to do.
+4|And Joseph found grace in the presence of his lord, and was well-pleasing to him; and he set him over his house, and all that he had he gave into the hand of Joseph.
+5|And it came to pass after that he was set over his house, and over all that he had, that the Lord blessed the house of the Egyptian for Joseph's sake; and the blessing of the Lord was on all his possessions in the house, and in his field.
+6|And he committed all that he had into the hands of Joseph; and he knew not of anything that belonged to him, save the bread which he himself ate. And Joseph was handsome in form, and exceedingly beautiful in countenance.
+7|And it came to pass after these things, that his master's wife cast her eyes upon Joseph, and said, Lie with me.
+8|But he would not; but said to his master's wife, If because of me my master knows nothing in his house, and has given into my hands all things that belong to him:
+9|and in this house there is nothing above me, nor has anything been kept back from me, but thou, because thou art his wife—how then shall I do this wicked thing, and sin against God?
+10|And when she talked with Joseph day by day, and he hearkened not to her to sleep with her, so as to be with her,
+11|it came to pass on a certain day, that Joseph went into the house to do his business, and there was no one of the household within.
+12|And she caught hold of him by his clothes, and said, Lie with me; and having left his clothes in her hands, he fled, and went forth.
+13|And it came to pass, when she saw that he had left his clothes in her hands, and fled, and gone forth,
+14|that she called those that were in the house, and spoke to them, saying, See, he has brought in to us a Hebrew servant to mock us—he came in to me, saying, Lie with me, and I cried with a loud voice.
+15|And when he heard that I lifted up my voice and cried, having left his clothes with me, he fled, and went forth out.
+16|So she leaves the clothes by her, until the master came to his house.
+17|And she spoke to him according to these words, saying, The Hebrew servant, whom thou broughtest in to us, came in to me to mock me, and said to me, I will lie with thee.
+18|And when he heard that I lifted up my voice and cried, having left his clothes with me, he fled and departed forth.
+19|And it came to pass, when his master heard all the words of his wife, that she spoke to him, saying, Thus did thy servant to me, that he was very angry.
+20|And his master took Joseph, and cast him into the prison, into the place where the king's prisoners are kept, there in the prison.
+21|And the Lord was with Joseph, and poured down mercy upon him; and he gave him favour in the sight of the chief keeper of the prison.
+22|And the chief keeper of the prison gave the prison into the hand of Joseph, and all the prisoners as many as were in the prison; and all things whatsoever they do there, he did them.
+23|Because of him the chief keeper of the prison knew nothing, for all things were in the hand of Joseph, because the Lord was with him; and whatever things he did, the Lord made them to prosper in his hands.
 
 #40
-1| And it came to pass after these things, that the chief cupbearer of the king of Egypt and the chief baker trespassed against their lord the king of Egypt. 
-2| And Pharao was wroth with his two eunuchs, with his chief cupbearer, and with his chief baker. 
-3| And he put them in ward, into the prison, into the place whereinto Joseph had been led. 
-4| And the chief keeper of the prison committed them to Joseph, and he stood by them; and they were <i>some</i> days in the prison. 
-5| And they both had a dream in one night; and the vision of the dream of the chief cupbearer and chief baker, who belonged to the king of Egypt, who were in the prison, was this. 
-6| Joseph went in to them in the morning, and saw them, and they had been troubled. 
-7| And he asked the eunuchs of Pharao who were with him in the prison with his master, saying, Why is it that your countenances are sad to-day? 
-8| And they said to him, We have seen a dream, and there is no interpreter of it. And Joseph said to them, Is not the interpretation of them through god? tell <i>them</i> than to me. 
-9| And the chief cupbearer related his dream to Joseph, and said, In my dream a vine was before me. 
-10| And in the vine <i>were</i> three stems; and it budding shot forth blossoms; the clusters of grapes were ripe. 
-11| And the cup of Pharao was in my hand; and I took the bunch of grapes, and squeezed it into the cup, and gave the cup into Pharao’s hand. 
-12| And Joseph said to him, This is the interpretation of it. The three stems are three days. 
-13| Yet three days and Pharao shall remember thy office, and he shall restore thee to thy place of chief cupbearer, and thou shalt give the cup of Pharao into his hand, according to thy former high place, as thou wast wont to be cupbearer. 
-14| But remember me of thyself, when it shall be well with thee, and thou shalt deal mercifully with me, and thou shalt make mention of me to Pharao, and thou shalt bring me forth out of this dungeon. 
-15| For surely I was stolen away out of the land of the Hebrews, and here I have done nothing, but they have cast me into this pit. 
-16| And the chief baker saw that he interpreted aright; and he said to Joseph, I also saw a dream, and methought I took up on my head three baskets of mealy food. 
-17| And in the upper basket there was the work of the baker of every kind which Pharao eats; and the fowls of the air ate them out of the basket that was on my head. 
-18| And Joseph answered and said to him, This is the interpretation of it; The three baskets are three days. 
-19| Yet three days, and Pharao shall take away thy head from off thee, and shall hang thee on a tree, and the birds of the sky shall eat thy flesh from off thee. 
-20| And it came to pass on the third day that it was Pharao’s birth-day, and he made a banquet for all his servants, and he remembered the office of the cupbearer and the office of the baker in the midst of his servants. 
-21| And he restored the chief cupbearer to his office, and he gave the cup into Pharao’s hand. 
-22| And he hanged the chief baker, as Joseph, interpreted to them. 
-23| Yet did not the chief cupbearer remember Joseph, but forgot him. 	1 	
+1|And it came to pass after these things, that the chief cupbearer of the king of Egypt and the chief baker trespassed against their lord the king of Egypt.
+2|And Pharao was wroth with his two eunuchs, with his chief cupbearer, and with his chief baker.
+3|And he put them in ward, into the prison, into the place whereinto Joseph had been led.
+4|And the chief keeper of the prison committed them to Joseph, and he stood by them; and they were <i>some</i> days in the prison.
+5|And they both had a dream in one night; and the vision of the dream of the chief cupbearer and chief baker, who belonged to the king of Egypt, who were in the prison, was this.
+6|Joseph went in to them in the morning, and saw them, and they had been troubled.
+7|And he asked the eunuchs of Pharao who were with him in the prison with his master, saying, Why is it that your countenances are sad to-day?
+8|And they said to him, We have seen a dream, and there is no interpreter of it. And Joseph said to them, Is not the interpretation of them through god? tell <i>them</i> than to me.
+9|And the chief cupbearer related his dream to Joseph, and said, In my dream a vine was before me.
+10|And in the vine <i>were</i> three stems; and it budding shot forth blossoms; the clusters of grapes were ripe.
+11|And the cup of Pharao was in my hand; and I took the bunch of grapes, and squeezed it into the cup, and gave the cup into Pharao's hand.
+12|And Joseph said to him, This is the interpretation of it. The three stems are three days.
+13|Yet three days and Pharao shall remember thy office, and he shall restore thee to thy place of chief cupbearer, and thou shalt give the cup of Pharao into his hand, according to thy former high place, as thou wast wont to be cupbearer.
+14|But remember me of thyself, when it shall be well with thee, and thou shalt deal mercifully with me, and thou shalt make mention of me to Pharao, and thou shalt bring me forth out of this dungeon.
+15|For surely I was stolen away out of the land of the Hebrews, and here I have done nothing, but they have cast me into this pit.
+16|And the chief baker saw that he interpreted aright; and he said to Joseph, I also saw a dream, and methought I took up on my head three baskets of mealy food.
+17|And in the upper basket there was the work of the baker of every kind which Pharao eats; and the fowls of the air ate them out of the basket that was on my head.
+18|And Joseph answered and said to him, This is the interpretation of it; The three baskets are three days.
+19|Yet three days, and Pharao shall take away thy head from off thee, and shall hang thee on a tree, and the birds of the sky shall eat thy flesh from off thee.
+20|And it came to pass on the third day that it was Pharao's birth-day, and he made a banquet for all his servants, and he remembered the office of the cupbearer and the office of the baker in the midst of his servants.
+21|And he restored the chief cupbearer to his office, and he gave the cup into Pharao's hand.
+22|And he hanged the chief baker, as Joseph, interpreted to them.
+23|Yet did not the chief cupbearer remember Joseph, but forgot him.
 
 #41
-1| And it came to pass after two full years that Pharao had a dream. He thought he stood upon <i>the bank of</i> the river. 
-2| And lo, there came up as it were out of the river seven cows, fair in appearance, and choice of flesh, and they fed on the sedge. 
-3| And other seven cows came up after these out of the river, ill-favoured and lean-fleshed, and fed by the <i>other</i> cows on the bank of the river. 
-4| And the seven ill-favoured and lean cows devoured the seven well-favoured and choice-fleshed cows; and Pharao awoke. 
-5| And he dreamed again. And, behold, seven ears came up on one stalk, choice and good. 
-6| And, behold, seven ears thin and blasted with the wind, grew up after them. 
-7| And the seven thin ears and blasted with the wind devoured the seven choice and full ears; and Pharao awoke, and it was a dream. 
-8| And it was morning, and his soul was troubled; and he sent and called all the interpreters of Egypt, and all her wise men; and Pharao related to them his dream, and there was no one to interpret it to Pharao. 
-9| And the chief cupbearer spoke to Pharao, saying, I this day remember my fault: 
-10| Pharao was angry with his servants, and put us in prison in the house of the captain of the guard, both me and the chief baker. 
-11| And we had a dream both in one night, I and he; we saw, each according to his dream. 
-12| And there was there with us a young man, a Hebrew servant of the captain of the guard; and we related to him <i>our dreams</i>, and he interpreted <i>them</i> to us. 
-13| And it came to pass, as he interpreted them to us, so also it happened, both that I was restored to my office, and that he was hanged. 
-14| And Pharao having sent, called Joseph; and they brought him out from the prison, and shaved him, and changed his dress, and he came to Pharao. 
-15| And Pharao said to Joseph, I have seen a vision, and there is no one to interpret it; but I have heard say concerning thee that thou didst hear dreams and interpret them. 
-16| And Joseph answered Pharao and said, Without God an answer of safety shall not be given to Pharao. 
-17| And Pharao spoke to Joseph, saying, In my dream methought I stood by the bank of the river; 
-18| and there came up as it were out of the river, seven cows well-favoured and choice-fleshed, and they fed on the sedge. 
-19| And behold seven other cows came up after them out of the river, evil and ill-favoured and lean-fleshed, such that I never saw worse in all the land of Egypt. 
-20| And the seven ill-favoured and thin cows ate up the seven first good and choice cows. 
-21| And they went into their bellies; and it was not perceptible that they had gone into their bellies, and their appearance was ill-favoured, as also at the beginning; and after I awoke I slept, 
-22| and saw again in my sleep, and as it were seven ears came up on one stem, full and good. 
-23| And other seven ears, thin and blasted with the wind, sprang up close to them. 
-24| And the seven thin and blasted ears devoured the seven fine and full ears: so I spoke to the interpreters, and there was no one to explain it to me.  	
-25| And Joseph said to Pharao, The dream of Pharao is one; whatever God does, he has shewn to Pharao. 
-26| The seven good cows are seven years, and the seven good ears are seven years; the dream of Pharao is one. 
-27| And the seven thin kine that came up after them are seven years; and the seven thin and blasted ears are seven years; there shall be seven years of famine. 
-28| And as for the word which I have told Pharao, whatsoever God intends to do, he has shewn to Pharao: 
-29| behold, for seven years there is coming great plenty in all the land of Egypt. 
-30| But there shall come seven years of famine after these, and they shall forget the plenty that shall be in all Egypt, and the famine shall consume the land. 
-31| And the plenty shall not be known in the land by reason of the famine that shall be after this, for it shall be very grievous. 
-32| And concerning the repetition of the dream to Pharao twice, <i>it is</i> because the saying which is from God shall be true, and God will hasten to accomplish it. 
-33| Now then, look out a wise and prudent man, and set him over the land of Egypt. 
-34| And let Pharao make and appoint local governors over the land; and let them take up a fifth part of all the produce of the land of Egypt for the seven years of the plenty. 
-35| And let them gather all the food of these seven good years that are coming, and let the corn be gathered under the hand of Pharao; let food be kept in the cities. 
-36| And the stored food shall be for the land against the seven years of famine, which shall be in the land of Egypt; and the land shall not be utterly destroyed by the famine. 
-37| And the word was pleasing in the sight of Pharao, and in the sight of all his servants.  	
-38| And Pharao said to all his servants, Shall we find such a man as this, who has the Spirit of God in him? 
-39| And Pharao said to Joseph, Since God has shewed thee all these things, there is not a wiser or more prudent man than thou. 
-40| Thou shalt be over my house, and all my people shall be obedient to thy word; only in the throne will I excel thee. 
-41| And Pharao said to Joseph, Behold, I set thee this day over all the land of Egypt. 
-42| And Pharao took his ring off his hand, and put it on the hand of Joseph, and put on him a robe of fine linen, and put a necklace of gold about his neck. 
-43| And he mounted him on the second of his chariots, and a herald made proclamation before him; and he set him over all the land of Egypt. 
-44| And Pharao said to Joseph, I am Pharao; without thee no one shall lift up his hand on all the land of Egypt. 
-45| And Pharao called the name of Joseph, Psonthomphanech; and he gave him Aseneth, the daughter of Petephres, priest of Heliopolis, to wife. 
-46| And Joseph was thirty years old when he stood before Pharao, king of Egypt. And Joseph went out from the presence of Pharao, and went through all the land of Egypt. 
-47| And the land produced, in the seven years of plenty, <i>whole</i> handfuls <i>of corn</i>. 
-48| And he gathered all the food of the seven years, in which was the plenty in the land of Egypt; and he laid up the food in the cities; the food of the fields of a city round about it he laid up in it. 
-49| And Joseph gathered very much corn as the sand of the sea, until it could not be numbered, for there was no number <i>of it</i>.  	
-50| And to Joseph were born two sons, before the seven years of famine came, which Aseneth, the daughter of Petephres, priest of Heliopolis, bore to him. 
-51| And Joseph called the name of the first-born, Manasse; for God, <i>said he</i>, has made me forget all my toils, and all my father’s house. 
-52| And he called the name of the second, Ephraim; for God, <i>said he</i>, has increased me in the land of my humiliation. 
-53| And the seven years of plenty passed away, which were in the land of Egypt. 
-54| And the seven years of famine began to come, as Joseph said; and there was a famine in all the land; but in all the land of Egypt there was bread. 
-55| And all the land of Egypt was hungry; and the people cried to Pharao for bread. And Pharao said to all the Egyptians, Go to Joseph, and do whatsoever he shall tell you. 
-56| And the famine was on the face of all the earth; and Joseph opened all the granaries, and sold to all the Egyptians. 
-57| And all countries came to Egypt to buy of Joseph, for the famine prevailed in all the earth. 	2 	
+1|And it came to pass after two full years that Pharao had a dream. He thought he stood upon <i>the bank of</i> the river.
+2|And lo, there came up as it were out of the river seven cows, fair in appearance, and choice of flesh, and they fed on the sedge.
+3|And other seven cows came up after these out of the river, ill-favoured and lean-fleshed, and fed by the <i>other</i> cows on the bank of the river.
+4|And the seven ill-favoured and lean cows devoured the seven well-favoured and choice-fleshed cows; and Pharao awoke.
+5|And he dreamed again. And, behold, seven ears came up on one stalk, choice and good.
+6|And, behold, seven ears thin and blasted with the wind, grew up after them.
+7|And the seven thin ears and blasted with the wind devoured the seven choice and full ears; and Pharao awoke, and it was a dream.
+8|And it was morning, and his soul was troubled; and he sent and called all the interpreters of Egypt, and all her wise men; and Pharao related to them his dream, and there was no one to interpret it to Pharao.
+9|And the chief cupbearer spoke to Pharao, saying, I this day remember my fault:
+10|Pharao was angry with his servants, and put us in prison in the house of the captain of the guard, both me and the chief baker.
+11|And we had a dream both in one night, I and he; we saw, each according to his dream.
+12|And there was there with us a young man, a Hebrew servant of the captain of the guard; and we related to him <i>our dreams</i>, and he interpreted <i>them</i> to us.
+13|And it came to pass, as he interpreted them to us, so also it happened, both that I was restored to my office, and that he was hanged.
+14|And Pharao having sent, called Joseph; and they brought him out from the prison, and shaved him, and changed his dress, and he came to Pharao.
+15|And Pharao said to Joseph, I have seen a vision, and there is no one to interpret it; but I have heard say concerning thee that thou didst hear dreams and interpret them.
+16|And Joseph answered Pharao and said, Without God an answer of safety shall not be given to Pharao.
+17|And Pharao spoke to Joseph, saying, In my dream methought I stood by the bank of the river;
+18|and there came up as it were out of the river, seven cows well-favoured and choice-fleshed, and they fed on the sedge.
+19|And behold seven other cows came up after them out of the river, evil and ill-favoured and lean-fleshed, such that I never saw worse in all the land of Egypt.
+20|And the seven ill-favoured and thin cows ate up the seven first good and choice cows.
+21|And they went into their bellies; and it was not perceptible that they had gone into their bellies, and their appearance was ill-favoured, as also at the beginning; and after I awoke I slept,
+22|and saw again in my sleep, and as it were seven ears came up on one stem, full and good.
+23|And other seven ears, thin and blasted with the wind, sprang up close to them.
+24|And the seven thin and blasted ears devoured the seven fine and full ears: so I spoke to the interpreters, and there was no one to explain it to me.
+25|And Joseph said to Pharao, The dream of Pharao is one; whatever God does, he has shewn to Pharao.
+26|The seven good cows are seven years, and the seven good ears are seven years; the dream of Pharao is one.
+27|And the seven thin kine that came up after them are seven years; and the seven thin and blasted ears are seven years; there shall be seven years of famine.
+28|And as for the word which I have told Pharao, whatsoever God intends to do, he has shewn to Pharao:
+29|behold, for seven years there is coming great plenty in all the land of Egypt.
+30|But there shall come seven years of famine after these, and they shall forget the plenty that shall be in all Egypt, and the famine shall consume the land.
+31|And the plenty shall not be known in the land by reason of the famine that shall be after this, for it shall be very grievous.
+32|And concerning the repetition of the dream to Pharao twice, <i>it is</i> because the saying which is from God shall be true, and God will hasten to accomplish it.
+33|Now then, look out a wise and prudent man, and set him over the land of Egypt.
+34|And let Pharao make and appoint local governors over the land; and let them take up a fifth part of all the produce of the land of Egypt for the seven years of the plenty.
+35|And let them gather all the food of these seven good years that are coming, and let the corn be gathered under the hand of Pharao; let food be kept in the cities.
+36|And the stored food shall be for the land against the seven years of famine, which shall be in the land of Egypt; and the land shall not be utterly destroyed by the famine.
+37|And the word was pleasing in the sight of Pharao, and in the sight of all his servants.
+38|And Pharao said to all his servants, Shall we find such a man as this, who has the Spirit of God in him?
+39|And Pharao said to Joseph, Since God has shewed thee all these things, there is not a wiser or more prudent man than thou.
+40|Thou shalt be over my house, and all my people shall be obedient to thy word; only in the throne will I excel thee.
+41|And Pharao said to Joseph, Behold, I set thee this day over all the land of Egypt.
+42|And Pharao took his ring off his hand, and put it on the hand of Joseph, and put on him a robe of fine linen, and put a necklace of gold about his neck.
+43|And he mounted him on the second of his chariots, and a herald made proclamation before him; and he set him over all the land of Egypt.
+44|And Pharao said to Joseph, I am Pharao; without thee no one shall lift up his hand on all the land of Egypt.
+45|And Pharao called the name of Joseph, Psonthomphanech; and he gave him Aseneth, the daughter of Petephres, priest of Heliopolis, to wife.
+46|And Joseph was thirty years old when he stood before Pharao, king of Egypt. And Joseph went out from the presence of Pharao, and went through all the land of Egypt.
+47|And the land produced, in the seven years of plenty, <i>whole</i> handfuls <i>of corn</i>.
+48|And he gathered all the food of the seven years, in which was the plenty in the land of Egypt; and he laid up the food in the cities; the food of the fields of a city round about it he laid up in it.
+49|And Joseph gathered very much corn as the sand of the sea, until it could not be numbered, for there was no number <i>of it</i>.
+50|And to Joseph were born two sons, before the seven years of famine came, which Aseneth, the daughter of Petephres, priest of Heliopolis, bore to him.
+51|And Joseph called the name of the first-born, Manasse; for God, <i>said he</i>, has made me forget all my toils, and all my father's house.
+52|And he called the name of the second, Ephraim; for God, <i>said he</i>, has increased me in the land of my humiliation.
+53|And the seven years of plenty passed away, which were in the land of Egypt.
+54|And the seven years of famine began to come, as Joseph said; and there was a famine in all the land; but in all the land of Egypt there was bread.
+55|And all the land of Egypt was hungry; and the people cried to Pharao for bread. And Pharao said to all the Egyptians, Go to Joseph, and do whatsoever he shall tell you.
+56|And the famine was on the face of all the earth; and Joseph opened all the granaries, and sold to all the Egyptians.
+57|And all countries came to Egypt to buy of Joseph, for the famine prevailed in all the earth.
 
 #42
-1| And Jacob having seen that there was a sale <i>of corn</i> in Egypt, said to his sons, Why are ye indolent? 
-2| Behold, I have heard that there is corn in Egypt; go down thither, and buy for us a little food, that we may live, and not die.  	
-3| And the ten brethren of Joseph went down to buy corn out of Egypt. 
-4| But <i>Jacob</i> sent not Benjamin, the brother of Joseph, with his brethren; for he said, Lest, haply, disease befall him. 
-5| And the sons of Israel came to buy with those that came, for the famine was in the land of Chanaan. 
-6| And Joseph was ruler of the land; he sold to all the people of the land. And the brethren of Joseph, having come, did reverence to him, <i>bowing</i> with the face to the ground. 
-7| And when Joseph saw his brethren, he knew them, and estranged himself from them, and spoke hard words to them; and said to them, Whence are ye come? And they said, Out of the land of Chanaan, to buy food. 
-8| And Joseph knew his brethren, but they knew not him. 
-9| And Joseph remembered his dream, which he saw; and he said to them, Ye are spies; to observe the marks of the land are ye come. 
-10| But they said, Nay, Sir, we thy servants are come to buy food; 
-11| we are all sons of one man; we are peaceable, thy servants are not spies. 
-12| And he said to them, Nay, but ye are come to observe the marks of the land. 
-13| And they said, We thy servants are twelve brethren, in the land of Chanaan; and, behold, the youngest is with our father to-day, but the other one is not. 
-14| And Joseph said to them, This is it that I spoke to you, saying, ye are spies; 
-15| herein shall ye be manifested; by the health of Pharao, ye shall not depart hence, unless your younger brother come hither. 
-16| Send one of you, and take your brother; and go ye to prison, till your words be clear, whether ye speak the truth or not; but, if not, by the health of Pharao, verily ye are spies. 
-17| And he put them in prison three days. 
-18| And he said to them on the third day, This do, and ye shall live, for I fear God. 
-19| If ye be peaceable, let one of your brethren be detained in prison; but go ye, and carry back the corn ye have purchased. 
-20| And bring your younger brother to me, and your words shall be believed; but, if not, ye shall die. And they did so. 
-21| And each said to his brother, Yes, indeed, for we are in fault concerning our brother, when we disregarded the anguish of his soul, when he besought us, and we hearkened not to him; and therefore has this affliction come upon us. 
-22| And Ruben answered them, saying, Did I not speak to you, saying, Hurt not the boy, and ye heard me not? and, behold, his blood is required. 
-23| But they knew not that Joseph understood them; for there was an interpreter between them. 
-24| And Joseph turned away from them, and wept; and again he came to them, and spoke to them; and he took Symeon from them, and bound him before their eyes.  	
-25| And Joseph gave orders to fill their vessels with corn, and to return their money to each into his sack, and to give them provision for the way; and it was so done to them. 
-26| And having put the corn on the asses, they departed thence. 
-27| And one having opened his sack to give his asses fodder, at the place where they rested, saw also his bundle of money, for it was on the mouth of his sack. 
-28| And he said to his brethren, My money has been restored to me, and behold this is in my sack. And their heart was wonder-struck, and they were troubled, saying one to another, What is this that God has done to us? 
-29| And they came to their father, Jacob, into the land of Chanaan, and reported to him all that had happened to them, saying, 
-30| The man, the lord of the land, spoke harsh words to us, and put us in prison as spies of the land. 
-31| And we said to him, We are men of peace, we are not spies. 
-32| We are twelve brethren, sons of our father; one is not, and the youngest is with his father to-day in the land of Chanaan. 
-33| And the man, the lord of the land, said to us, Herein shall I know that ye are peaceable; leave one brother here with me, and having taken the corn ye have purchased for your family, depart. 
-34| And bring to me your younger brother; then I shall know that ye are not spies, but that ye are men of peace: and I will restore you your brother, and ye shall trade in the land. 
-35| And it came to pass as they were emptying their sacks, there was each man’s bundle of money in his sack; and they and their father saw their bundles of money, and they were afraid. 
-36| And their father Jacob said to them, Ye have bereaved me. Joseph is not, Symeon is not, and will ye take Benjamin? all these things have come upon me. 
-37| And Ruben spoke to his father, saying, Slay my two sons, if I bring him not to thee; give him into my hand, and I will bring him back to thee. 
-38| But he said, My son shall not go down with you, because his brother is dead, and he only has been left; and <i>suppose</i> it shall come to pass that he is afflicted by the way by which ye go, then ye shall bring down my old age with sorrow to Hades. 	3 	
+1|And Jacob having seen that there was a sale <i>of corn</i> in Egypt, said to his sons, Why are ye indolent?
+2|Behold, I have heard that there is corn in Egypt; go down thither, and buy for us a little food, that we may live, and not die.
+3|And the ten brethren of Joseph went down to buy corn out of Egypt.
+4|But <i>Jacob</i> sent not Benjamin, the brother of Joseph, with his brethren; for he said, Lest, haply, disease befall him.
+5|And the sons of Israel came to buy with those that came, for the famine was in the land of Chanaan.
+6|And Joseph was ruler of the land; he sold to all the people of the land. And the brethren of Joseph, having come, did reverence to him, <i>bowing</i> with the face to the ground.
+7|And when Joseph saw his brethren, he knew them, and estranged himself from them, and spoke hard words to them; and said to them, Whence are ye come? And they said, Out of the land of Chanaan, to buy food.
+8|And Joseph knew his brethren, but they knew not him.
+9|And Joseph remembered his dream, which he saw; and he said to them, Ye are spies; to observe the marks of the land are ye come.
+10|But they said, Nay, Sir, we thy servants are come to buy food;
+11|we are all sons of one man; we are peaceable, thy servants are not spies.
+12|And he said to them, Nay, but ye are come to observe the marks of the land.
+13|And they said, We thy servants are twelve brethren, in the land of Chanaan; and, behold, the youngest is with our father to-day, but the other one is not.
+14|And Joseph said to them, This is it that I spoke to you, saying, ye are spies;
+15|herein shall ye be manifested; by the health of Pharao, ye shall not depart hence, unless your younger brother come hither.
+16|Send one of you, and take your brother; and go ye to prison, till your words be clear, whether ye speak the truth or not; but, if not, by the health of Pharao, verily ye are spies.
+17|And he put them in prison three days.
+18|And he said to them on the third day, This do, and ye shall live, for I fear God.
+19|If ye be peaceable, let one of your brethren be detained in prison; but go ye, and carry back the corn ye have purchased.
+20|And bring your younger brother to me, and your words shall be believed; but, if not, ye shall die. And they did so.
+21|And each said to his brother, Yes, indeed, for we are in fault concerning our brother, when we disregarded the anguish of his soul, when he besought us, and we hearkened not to him; and therefore has this affliction come upon us.
+22|And Ruben answered them, saying, Did I not speak to you, saying, Hurt not the boy, and ye heard me not? and, behold, his blood is required.
+23|But they knew not that Joseph understood them; for there was an interpreter between them.
+24|And Joseph turned away from them, and wept; and again he came to them, and spoke to them; and he took Symeon from them, and bound him before their eyes.
+25|And Joseph gave orders to fill their vessels with corn, and to return their money to each into his sack, and to give them provision for the way; and it was so done to them.
+26|And having put the corn on the asses, they departed thence.
+27|And one having opened his sack to give his asses fodder, at the place where they rested, saw also his bundle of money, for it was on the mouth of his sack.
+28|And he said to his brethren, My money has been restored to me, and behold this is in my sack. And their heart was wonder-struck, and they were troubled, saying one to another, What is this that God has done to us?
+29|And they came to their father, Jacob, into the land of Chanaan, and reported to him all that had happened to them, saying,
+30|The man, the lord of the land, spoke harsh words to us, and put us in prison as spies of the land.
+31|And we said to him, We are men of peace, we are not spies.
+32|We are twelve brethren, sons of our father; one is not, and the youngest is with his father to-day in the land of Chanaan.
+33|And the man, the lord of the land, said to us, Herein shall I know that ye are peaceable; leave one brother here with me, and having taken the corn ye have purchased for your family, depart.
+34|And bring to me your younger brother; then I shall know that ye are not spies, but that ye are men of peace: and I will restore you your brother, and ye shall trade in the land.
+35|And it came to pass as they were emptying their sacks, there was each man's bundle of money in his sack; and they and their father saw their bundles of money, and they were afraid.
+36|And their father Jacob said to them, Ye have bereaved me. Joseph is not, Symeon is not, and will ye take Benjamin? all these things have come upon me.
+37|And Ruben spoke to his father, saying, Slay my two sons, if I bring him not to thee; give him into my hand, and I will bring him back to thee.
+38|But he said, My son shall not go down with you, because his brother is dead, and he only has been left; and <i>suppose</i> it shall come to pass that he is afflicted by the way by which ye go, then ye shall bring down my old age with sorrow to Hades.
 
 #43
-1| But the famine prevailed in the land. 
-2| And it came to pass, when they had finished eating the corn which they had brought out of Egypt, that their father said to them, Go again; buy us a little food. 
-3| And Judas spoke to him, saying, The man, the lord of the country, positively testified to us, saying, Ye shall not see my face, unless your younger brother be with you. 
-4| If, then, thou send our brother with us, we will go down, and buy thee food; 
-5| but if thou send not our brother with us, we will not go: for the man spoke to us, saying, Ye shall not see my face, unless your younger brother be with you. 
-6| And Israel said, Why did ye harm me, inasmuch as ye told the man that ye had a brother? 
-7| And they said, The man closely questioned us about our family also, saying, Does your father yet live, and have ye a brother? and we answered him according to this question: did we know that he would say to us, Bring your brother? 
-8| And Judas said to his father Israel, Send the boy with me, and we will arise and go, that we may live and not die, both we and thou, and our store. 
-9| And I engage for him; at my hand do thou require him; if I bring him not to thee, and place him before thee, I shall be guilty toward thee for ever. 
-10| For if we had not tarried, we should now have returned twice. 
-11| And Israel, their father, said to them, If it be so, do this; take of the fruits of the earth in your vessels, and carry down to the man presents of gum and honey, and frankincense, and stacte, and turpentine, and walnuts. 
-12| And take double money in your hands, and the money that was returned in your sacks, carry back with you, lest peradventure it is a mistake. 
-13| And take your brother; and arise, go down to the man. 
-14| And my God give you favour in the sight of the man, and send away your other brother, and Benjamin, for I accordingly as I have been bereaved, am bereaved. 	
-15| And the men having taken these presents, and the double money, took in their hands also Benjamin; and they rose up and went down to Egypt, and stood before Joseph. 
-16| And Joseph saw them and his brother Benjamin, born of the same mother; and he said to the steward of his household, Bring the men into the house, and slay beasts and make ready, for the men are to eat bread with me at noon. 
-17| And the man did as Joseph said; and he brought the men into the house of Joseph. 
-18| And the men, when they perceived that they were brought into the house of Joseph, said, We are brought in because of the money that was returned in our sacks at the first; even in order to inform against us, and lay it to our charge; to take us for servants, and our asses. 
-19| And having approached the man who was over the house of Joseph, they spoke to him in the porch of the house, 
-20| saying, We pray <i>thee</i>, Sir; we came down at first to buy food. 
-21| And it came to pass, when we came to unlade, and opened our sacks, <i>there was</i> also this money of each in his sack; we have now brought back our money by weight in our hands. 
-22| And we have brought other money with us to buy food; we know not who put the money into our sacks. 
-23| And he said to them, <i>God deal</i> mercifully with you; be not afraid; your God, and the God of your fathers, has given you treasures in your sacks, and I have enough of your good money. And he brought Symeon out to them. 
-24| And he brought water to wash their feet; and gave provender to their asses. 
-25| And they prepared their gifts, until Joseph came at noon, for they heard that he was going to dine there. 
-26| And Joseph entered into the house, and they brought him the gifts which they had in their hands, into the house; and they did him reverence with their face to the ground. 
-27| And he asked them, How are ye? and he said to them, Is your father, the old man of whom ye spoke, well? Does he yet live? 
-28| And they said, Thy servant our father is well; he is yet alive. And he said, Blessed be that man by God; —and they bowed, and did him reverence. 
-29| And Joseph lifted up his eyes, and saw his brother Benjamin, born of the same mother; and he said, Is this your younger brother, whom ye spoke of bringing to me? and he said, God have mercy on thee, my son. 
-30| And Joseph was troubled, for his bowels yearned over his brother, and he sought to weep; and he went into his chamber, and wept there.  	
-31| And he washed his face and came out, and refrained himself, and said, Set on bread. 
-32| And they set on <i>bread</i> for him alone, and for them by themselves, and for the Egyptians feasting with him by themselves, for the Egyptians could not eat bread with the Hebrews, for it is an abomination to the Egyptians. 
-33| And they sat before him, the first-born according to his seniority, and the younger according to his youth; and the men looked with amazement every one at his brother. 
-34| And they took their portions from him to themselves; but Benjamin’s portion was five times as much as the portions of <i>the others</i>. And they drank and were filled with drink with him. 	4 	
+1|But the famine prevailed in the land.
+2|And it came to pass, when they had finished eating the corn which they had brought out of Egypt, that their father said to them, Go again; buy us a little food.
+3|And Judas spoke to him, saying, The man, the lord of the country, positively testified to us, saying, Ye shall not see my face, unless your younger brother be with you.
+4|If, then, thou send our brother with us, we will go down, and buy thee food;
+5|but if thou send not our brother with us, we will not go: for the man spoke to us, saying, Ye shall not see my face, unless your younger brother be with you.
+6|And Israel said, Why did ye harm me, inasmuch as ye told the man that ye had a brother?
+7|And they said, The man closely questioned us about our family also, saying, Does your father yet live, and have ye a brother? and we answered him according to this question: did we know that he would say to us, Bring your brother?
+8|And Judas said to his father Israel, Send the boy with me, and we will arise and go, that we may live and not die, both we and thou, and our store.
+9|And I engage for him; at my hand do thou require him; if I bring him not to thee, and place him before thee, I shall be guilty toward thee for ever.
+10|For if we had not tarried, we should now have returned twice.
+11|And Israel, their father, said to them, If it be so, do this; take of the fruits of the earth in your vessels, and carry down to the man presents of gum and honey, and frankincense, and stacte, and turpentine, and walnuts.
+12|And take double money in your hands, and the money that was returned in your sacks, carry back with you, lest peradventure it is a mistake.
+13|And take your brother; and arise, go down to the man.
+14|And my God give you favour in the sight of the man, and send away your other brother, and Benjamin, for I accordingly as I have been bereaved, am bereaved.
+15|And the men having taken these presents, and the double money, took in their hands also Benjamin; and they rose up and went down to Egypt, and stood before Joseph.
+16|And Joseph saw them and his brother Benjamin, born of the same mother; and he said to the steward of his household, Bring the men into the house, and slay beasts and make ready, for the men are to eat bread with me at noon.
+17|And the man did as Joseph said; and he brought the men into the house of Joseph.
+18|And the men, when they perceived that they were brought into the house of Joseph, said, We are brought in because of the money that was returned in our sacks at the first; even in order to inform against us, and lay it to our charge; to take us for servants, and our asses.
+19|And having approached the man who was over the house of Joseph, they spoke to him in the porch of the house,
+20|saying, We pray <i>thee</i>, Sir; we came down at first to buy food.
+21|And it came to pass, when we came to unlade, and opened our sacks, <i>there was</i> also this money of each in his sack; we have now brought back our money by weight in our hands.
+22|And we have brought other money with us to buy food; we know not who put the money into our sacks.
+23|And he said to them, <i>God deal</i> mercifully with you; be not afraid; your God, and the God of your fathers, has given you treasures in your sacks, and I have enough of your good money. And he brought Symeon out to them.
+24|And he brought water to wash their feet; and gave provender to their asses.
+25|And they prepared their gifts, until Joseph came at noon, for they heard that he was going to dine there.
+26|And Joseph entered into the house, and they brought him the gifts which they had in their hands, into the house; and they did him reverence with their face to the ground.
+27|And he asked them, How are ye? and he said to them, Is your father, the old man of whom ye spoke, well? Does he yet live?
+28|And they said, Thy servant our father is well; he is yet alive. And he said, Blessed be that man by God; —and they bowed, and did him reverence.
+29|And Joseph lifted up his eyes, and saw his brother Benjamin, born of the same mother; and he said, Is this your younger brother, whom ye spoke of bringing to me? and he said, God have mercy on thee, my son.
+30|And Joseph was troubled, for his bowels yearned over his brother, and he sought to weep; and he went into his chamber, and wept there.
+31|And he washed his face and came out, and refrained himself, and said, Set on bread.
+32|And they set on <i>bread</i> for him alone, and for them by themselves, and for the Egyptians feasting with him by themselves, for the Egyptians could not eat bread with the Hebrews, for it is an abomination to the Egyptians.
+33|And they sat before him, the first-born according to his seniority, and the younger according to his youth; and the men looked with amazement every one at his brother.
+34|And they took their portions from him to themselves; but Benjamin's portion was five times as much as the portions of <i>the others</i>. And they drank and were filled with drink with him.
 
 #44
-1| And Joseph charged the steward of his house, saying, Fill the men’s sacks with food, as much as they can carry, and put the money of each in the mouth of his sack. 
-2| And put my silver cup into the sack of the youngest, and the price of his corn. And it was done according to the word of Joseph, as he said.  	
-3| The morning dawned, and the men were sent away, they and their asses. 
-4| And when they had gone out of the city, <i>and</i> were not far off, then Joseph said to his steward, Arise, and pursue after the men; and thou shalt overtake them, and say to them, Why have ye returned evil for good? 
-5| Why have ye stolen my silver cup? is it not this out of which my lord drinks? and he divines augury with it; ye have accomplished evil in that which ye have done. 
-6| And he found them, and spoke to them according to these words. 
-7| And they said to him, Why does our lord speak according to these words? far be it from thy servants to do according to this word. 
-8| If we brought back to thee out of the land of Chanaan the money which we found in our sacks, how should we steal silver or gold out of the house of thy lord? 
-9| With whomsoever of thy servants thou shalt find the cup, let him die; and, moreover, we will be servants to our lord. 
-10| And he said, Now then it shall be as ye say; with whomsoever the cup shall be found, he shall be my servant, and ye shall be clear. 
-11| And they hasted, and took down every man his sack on the ground, and they opened every man his sack. 
-12| And he searched, beginning from the eldest, until he came to the youngest; and he found the cup in Benjamin’s sack. 
-13| And they rent their garments, and laid each man his sack on his ass, and returned to the city.  	
-14| And Judas and his brethren came in to Joseph, while he was yet there, and fell on the ground before him. 
-15| And Joseph said to them, What is this thing that ye have done? know ye not that a man such as I can surely divine? 
-16| And Judas said, What shall we answer to our lord, or what shall we say, or wherein should we be justified? whereas God has discovered the unrighteousness of thy servants; behold, we are slaves to our lord, both we and he with whom the cup has been found. 
-17| And Joseph said, Far be it from me to do this thing; the man with whom the cup has been found, he shall be my servant; but do ye go up with safety to your father. 
-18| And Judas drew near him, and said, I pray, Sir, let thy servant speak a word before thee, and be not angry with thy servant, for thou art next to Pharao. 
-19| Sir, thou askedst thy servants, saying, Have ye a father or a brother? 
-20| And we said to <i>my</i> lord, We have a father, an old man, and he has a son of his old age, a young one, and his brother is dead, and he alone has been left behind to his mother, and his father loves him. 
-21| And thou saidst to they servants, Bring him down to me, and I will take care of him. 
-22| And we said to <i>my</i> lord, The child will not be able to leave his father; but if he should leave his father, he will die. 
-23| But thou saidst to they servants, Except your younger brother come down with you, ye shall not see my face again. 
-24| And it came to pass, when we went up to thy servant our father, we reported to him the words of our lord. 
-25| And our father said, Go again, and buy us a little food. 
-26| And we said, We shall not be able to go down; but if our younger brother go down with us, we will go down; for we shall not be able to see the man’s face, our younger brother not being with us. 
-27| And thy servant our father said to us, Ye know that my wife bore me two <i>sons</i>; 
-28| and one is departed from me; and ye said that he was devoured of wild beasts, and I have not seen him until now. 
-29| If then ye take this one also from my presence, and an affliction happen to him by the way, then shall ye bring down my old age with sorrow to the grave. 
-30| Now then, if I should go in to they servant, and our father, and the boy should not be with us, (and his life depends on this <i>lad’s</i> life) 
-31| —it shall even come to pass, when he sees the boy is not with us, <i>that</i> he will die, and thy servants will bring down the old age of thy servant, and our father, with sorrow to the grave. 
-32| For thy servant has received the boy <i>in charge</i> from his father, saying, If I bring him not to thee, and place him before thee, I shall be guilty towards my father for ever. 
-33| Now then I will remain a servant with thee instead of the lad, a domestic of my lord; but let the lad go up with his brethren. 
-34| For how shall I go up to my father, the lad not being with us? lest I behold the evils which will befall my father. 	5 	
+1|And Joseph charged the steward of his house, saying, Fill the men's sacks with food, as much as they can carry, and put the money of each in the mouth of his sack.
+2|And put my silver cup into the sack of the youngest, and the price of his corn. And it was done according to the word of Joseph, as he said.
+3|The morning dawned, and the men were sent away, they and their asses.
+4|And when they had gone out of the city, <i>and</i> were not far off, then Joseph said to his steward, Arise, and pursue after the men; and thou shalt overtake them, and say to them, Why have ye returned evil for good?
+5|Why have ye stolen my silver cup? is it not this out of which my lord drinks? and he divines augury with it; ye have accomplished evil in that which ye have done.
+6|And he found them, and spoke to them according to these words.
+7|And they said to him, Why does our lord speak according to these words? far be it from thy servants to do according to this word.
+8|If we brought back to thee out of the land of Chanaan the money which we found in our sacks, how should we steal silver or gold out of the house of thy lord?
+9|With whomsoever of thy servants thou shalt find the cup, let him die; and, moreover, we will be servants to our lord.
+10|And he said, Now then it shall be as ye say; with whomsoever the cup shall be found, he shall be my servant, and ye shall be clear.
+11|And they hasted, and took down every man his sack on the ground, and they opened every man his sack.
+12|And he searched, beginning from the eldest, until he came to the youngest; and he found the cup in Benjamin's sack.
+13|And they rent their garments, and laid each man his sack on his ass, and returned to the city.
+14|And Judas and his brethren came in to Joseph, while he was yet there, and fell on the ground before him.
+15|And Joseph said to them, What is this thing that ye have done? know ye not that a man such as I can surely divine?
+16|And Judas said, What shall we answer to our lord, or what shall we say, or wherein should we be justified? whereas God has discovered the unrighteousness of thy servants; behold, we are slaves to our lord, both we and he with whom the cup has been found.
+17|And Joseph said, Far be it from me to do this thing; the man with whom the cup has been found, he shall be my servant; but do ye go up with safety to your father.
+18|And Judas drew near him, and said, I pray, Sir, let thy servant speak a word before thee, and be not angry with thy servant, for thou art next to Pharao.
+19|Sir, thou askedst thy servants, saying, Have ye a father or a brother?
+20|And we said to <i>my</i> lord, We have a father, an old man, and he has a son of his old age, a young one, and his brother is dead, and he alone has been left behind to his mother, and his father loves him.
+21|And thou saidst to they servants, Bring him down to me, and I will take care of him.
+22|And we said to <i>my</i> lord, The child will not be able to leave his father; but if he should leave his father, he will die.
+23|But thou saidst to they servants, Except your younger brother come down with you, ye shall not see my face again.
+24|And it came to pass, when we went up to thy servant our father, we reported to him the words of our lord.
+25|And our father said, Go again, and buy us a little food.
+26|And we said, We shall not be able to go down; but if our younger brother go down with us, we will go down; for we shall not be able to see the man's face, our younger brother not being with us.
+27|And thy servant our father said to us, Ye know that my wife bore me two <i>sons</i>;
+28|and one is departed from me; and ye said that he was devoured of wild beasts, and I have not seen him until now.
+29|If then ye take this one also from my presence, and an affliction happen to him by the way, then shall ye bring down my old age with sorrow to the grave.
+30|Now then, if I should go in to they servant, and our father, and the boy should not be with us, (and his life depends on this <i>lad's</i> life)
+31|—it shall even come to pass, when he sees the boy is not with us, <i>that</i> he will die, and thy servants will bring down the old age of thy servant, and our father, with sorrow to the grave.
+32|For thy servant has received the boy <i>in charge</i> from his father, saying, If I bring him not to thee, and place him before thee, I shall be guilty towards my father for ever.
+33|Now then I will remain a servant with thee instead of the lad, a domestic of my lord; but let the lad go up with his brethren.
+34|For how shall I go up to my father, the lad not being with us? lest I behold the evils which will befall my father.
 
 #45
-1| And Joseph could not refrain himself when all were standing by him, but said, Dismiss all from me; and no one stood near Joseph, when he made himself known to his brethren. 
-2| And he uttered his voice with weeping; and all the Egyptians heard, and it was reported to the house of Pharao. 
-3| And Joseph said to his brethren, I am Joseph; doth my father yet live? And his brethren could not answer him, for they were troubled. 
-4| And Joseph said to his brethren, Draw nigh to me; and they drew nigh; and he said, I am your brother Joseph, whom ye sold into Egypt. 
-5| Now then be not grieved, and let it not seem hard to you that ye sold me hither, for God sent me before you for life. 
-6| For this second year there is famine on the earth, and there are yet five years remaining, in which there is to be neither ploughing, nor mowing. 
-7| For God sent me before you, that there might be left to you a remnant upon the earth, even to nourish a great remnant of you. 
-8| Now then ye did not send me hither, but God; and he hath made me as a father of Pharao, and lord of all his house, and ruler of all the land of Egypt. 
-9| Hasten, therefore, and go up to my father, and say to him, These things saith thy son Joseph; God has made me lord of all the land of Egypt; come down therefore to me, and tarry not. 
-10| And thou shalt dwell in the land of Gesem of Arabia; and thou shalt be near me, thou and thy sons, and thy sons’ sons, thy sheep and thine oxen, and whatsoever things are thine. 
-11| And I will nourish thee there: for the famine is yet for five years; lest thou be consumed, and thy sons, and all thy possessions. 
-12| Behold, your eyes see, and the eyes of my brother Benjamin, that it is my mouth that speaks to you. 
-13| Report, therefore, to my father all my glory in Egypt, and all things that ye have seen, and make haste and bring down my father hither. 
-14| And he fell on his brother Benjamin’s neck, and wept on him; and Benjamin wept on his neck. 
-15| And he kissed all his brethren, and wept on them; and after these things his brethren spoke to him. 	
-16| And the report was carried into the house of Pharao, saying, Joseph’s brethren are come; and Pharao was glad, and his household. 
-17| And Pharao said to Joseph, Say to thy brethren, Do this; fill your waggons, and depart into the land of Chanaan. 
-18| And take up your father, and your possessions, and come to me; and I will give you of all the goods of Egypt, and ye shall eat the marrow of the land. 
-19| And do thou charge them thus; that they should take for them waggons out of the land of Egypt, for your little ones, and for your wives; and take up your father, and come. 
-20| And be not sparing in regard to your property, for all the good of Egypt shall be yours. 
-21| And the children of Israel did so; and Joseph gave to them waggons, according to the words spoken by king Pharao; and he gave them provision for the journey. 
-22| And he gave to them all two sets of raiment apiece; but to Benjamin he gave three hundred pieces of gold, and five changes of raiment. 
-23| And to his father he sent <i>presents</i> at the same rate, and ten asses, bearing some of all the good things of Egypt, and ten mules, bearing bread for his father for thy journey. 
-24| And he sent away his brethren, and they went; and he said to them, Be not angry by the way. 
-25| And they went up out of Egypt, and came into the land of Chanaan, to Jacob their father. 
-26| And they reported to him, saying, Thy son Joseph is living, and he is ruler over all the land of Egypt; and Jacob was amazed, for he did not believe them. 
-27| But they spoke to him all the words uttered by Joseph, whatsoever he said to them; and having seen the chariots which Joseph sent to take him up, the spirit of Jacob their father revived. 
-28| And Israel said, It is a great thing for me if Joseph my son is yet alive. I will go and see him before I die. 	6 	
+1|And Joseph could not refrain himself when all were standing by him, but said, Dismiss all from me; and no one stood near Joseph, when he made himself known to his brethren.
+2|And he uttered his voice with weeping; and all the Egyptians heard, and it was reported to the house of Pharao.
+3|And Joseph said to his brethren, I am Joseph; doth my father yet live? And his brethren could not answer him, for they were troubled.
+4|And Joseph said to his brethren, Draw nigh to me; and they drew nigh; and he said, I am your brother Joseph, whom ye sold into Egypt.
+5|Now then be not grieved, and let it not seem hard to you that ye sold me hither, for God sent me before you for life.
+6|For this second year there is famine on the earth, and there are yet five years remaining, in which there is to be neither ploughing, nor mowing.
+7|For God sent me before you, that there might be left to you a remnant upon the earth, even to nourish a great remnant of you.
+8|Now then ye did not send me hither, but God; and he hath made me as a father of Pharao, and lord of all his house, and ruler of all the land of Egypt.
+9|Hasten, therefore, and go up to my father, and say to him, These things saith thy son Joseph; God has made me lord of all the land of Egypt; come down therefore to me, and tarry not.
+10|And thou shalt dwell in the land of Gesem of Arabia; and thou shalt be near me, thou and thy sons, and thy sons' sons, thy sheep and thine oxen, and whatsoever things are thine.
+11|And I will nourish thee there: for the famine is yet for five years; lest thou be consumed, and thy sons, and all thy possessions.
+12|Behold, your eyes see, and the eyes of my brother Benjamin, that it is my mouth that speaks to you.
+13|Report, therefore, to my father all my glory in Egypt, and all things that ye have seen, and make haste and bring down my father hither.
+14|And he fell on his brother Benjamin's neck, and wept on him; and Benjamin wept on his neck.
+15|And he kissed all his brethren, and wept on them; and after these things his brethren spoke to him.
+16|And the report was carried into the house of Pharao, saying, Joseph's brethren are come; and Pharao was glad, and his household.
+17|And Pharao said to Joseph, Say to thy brethren, Do this; fill your waggons, and depart into the land of Chanaan.
+18|And take up your father, and your possessions, and come to me; and I will give you of all the goods of Egypt, and ye shall eat the marrow of the land.
+19|And do thou charge them thus; that they should take for them waggons out of the land of Egypt, for your little ones, and for your wives; and take up your father, and come.
+20|And be not sparing in regard to your property, for all the good of Egypt shall be yours.
+21|And the children of Israel did so; and Joseph gave to them waggons, according to the words spoken by king Pharao; and he gave them provision for the journey.
+22|And he gave to them all two sets of raiment apiece; but to Benjamin he gave three hundred pieces of gold, and five changes of raiment.
+23|And to his father he sent <i>presents</i> at the same rate, and ten asses, bearing some of all the good things of Egypt, and ten mules, bearing bread for his father for thy journey.
+24|And he sent away his brethren, and they went; and he said to them, Be not angry by the way.
+25|And they went up out of Egypt, and came into the land of Chanaan, to Jacob their father.
+26|And they reported to him, saying, Thy son Joseph is living, and he is ruler over all the land of Egypt; and Jacob was amazed, for he did not believe them.
+27|But they spoke to him all the words uttered by Joseph, whatsoever he said to them; and having seen the chariots which Joseph sent to take him up, the spirit of Jacob their father revived.
+28|And Israel said, It is a great thing for me if Joseph my son is yet alive. I will go and see him before I die.
 
 #46
-1| And Israel departed, he and all that he had, and came to the well of the oath; and he offered sacrifice to the God of his father Isaac. 
-2| And God spoke to Israel in a night vision, saying, Jacob, Jacob; and he said, What is it? 
-3| And he says to him, I am the God of thy fathers; fear not to go down into Egypt, for I will make thee there a great nation. 
-4| And I will go down with thee into Egypt, and I will bring thee up at the end; and Joseph shall put his hands on thine eyes. 
-5| And Jacob rose up from the well of the oath; and the sons of Israel took up their father, and the baggage, and their wives on the waggons, which Joseph sent to take them. 
-6| And they took up their goods, and all their property, which they had gotten in the land of Chanaan; they came into the land of Egypt, Jacob, and all his seed with him. 
-7| The sons, and the sons of his sons with him; <i>his</i> daughters, and the daughters of his daughters; and he brought all his seed into Egypt. 
-8| And these are the names of the sons of Israel that went into Egypt with their father Jacob—Jacob and his sons. The first-born of Jacob, Ruben. 
-9| And the sons of Ruben; Enoch, and Phallus, Asron, and Charmi. 
-10| and the sons of Symeon; Jemuel, and Jamin, and Aod, and Achin, and Saar, and Saul, the son of a Chananitish woman. 
-11| And the sons of Levi; Gerson, Cath, and Merari. 
-12| And the sons of Judas; Er, and Aunan, and Selom, and Phares, and Zara: and Er and Aunan died in the land of Chanaan. 
-13| And the sons of Phares <i>were</i> Esron, and Jemuel. And the sons of Issachar; Thola, and Phua, and Asum, and Sambran. 
-14| And the sons of Zabulun, Sered, and Allon, and Achoel. 
-15| These <i>are</i> the sons of Lea, which she bore to Jacob in Mesopotamia of Syria, and Dina his daughter; all the souls, sons and daughters, thirty-three. 
-16| And the sons of Gad; Saphon, and Angis, and Sannis, and Thasoban, and Aedis, and Aroedis, and Areelis. 
-17| And the sons of Aser; Jemna, Jessua, and Jeul, and Baria, and Sara their sister. And the sons of Baria; Chobor, and Melchiil. 
-18| These <i>are</i> the sons of Zelpha, which Laban gave to his daughter Lea, who bore these to Jacob, sixteen souls. 
-19| And the sons of Rachel, the wife of Jacob; Joseph, and Benjamin. 
-20| And there were sons born to Joseph in the land of Egypt, whom Aseneth, the daughter of Petephres, priest of Heliopolis, bore to him, <i>even</i> Manasses and Ephraim. And there were sons born to Manasses, which the Syrian concubine bore to him, <i>even</i> Machir. And Machir begot Galaad. And the sons of Ephraim, the brother of Manasses; Sutalaam, and Taam. And the sons of Sutalaam; Edom. 
-21| and the sons of Benjamin; Bala, and Bochor, and Asbel. And the sons of Bala were Gera, and Noeman, and Anchis, and Ros, and Mamphim. And Gera begot Arad. 
-22| These <i>are</i> the sons of Rachel, which she bore to Jacob; all the souls eighteen. 
-23| And the sons of Dan; Asom. 
-24| And the sons of Nephthalim; Asiel, and Goni, and Issaar, and Sollem. 
-25| These <i>are</i> the sons of Balla, whom Laban gave to his daughter Rachel, who bore these to Jacob; all the souls, seven. 
-26| And all the souls that came with Jacob into Egypt, who came out of his loins, besides the wives of the sons of Jacob, <i>even</i> all the souls were sixty-six. 
-27| And the sons of Joseph, who were born to him in the land of Egypt, were nine souls; all the souls of the house of Jacob who came with Joseph into Egypt, were seventy-five souls. 	
-28| And he sent Judas before him to Joseph, to meet him to the city of Heroes, into the land of Ramesses. 
-29| And Joseph having made ready his chariots, went up to meet Israel his father, at the city of Heroes; and having appeared to him, fell on his neck, and wept with abundant weeping. 
-30| And Israel said to Joseph, After this I will <i>gladly</i> die, since I have seen thy face, for thou art yet living. 
-31| And Joseph said to his brethren, I will go up and tell Pharao, and will say to him, My brethren, and my father’s house, who were in the land of Chanaan, are come to me. 
-32| And the men are shepherds; for they have been feeders of cattle, and they have brought with them their cattle, and their kine, and all their property. 
-33| If then Pharao call you, and say to you, What is you occupation? 
-34| Ye shall say, We thy servants are herdsmen from our youth until now, both we and our fathers: that ye may dwell in the land of Gesem of Arabia, for every shepherd is an abomination to the Egyptians. 	7 	
+1|And Israel departed, he and all that he had, and came to the well of the oath; and he offered sacrifice to the God of his father Isaac.
+2|And God spoke to Israel in a night vision, saying, Jacob, Jacob; and he said, What is it?
+3|And he says to him, I am the God of thy fathers; fear not to go down into Egypt, for I will make thee there a great nation.
+4|And I will go down with thee into Egypt, and I will bring thee up at the end; and Joseph shall put his hands on thine eyes.
+5|And Jacob rose up from the well of the oath; and the sons of Israel took up their father, and the baggage, and their wives on the waggons, which Joseph sent to take them.
+6|And they took up their goods, and all their property, which they had gotten in the land of Chanaan; they came into the land of Egypt, Jacob, and all his seed with him.
+7|The sons, and the sons of his sons with him; <i>his</i> daughters, and the daughters of his daughters; and he brought all his seed into Egypt.
+8|And these are the names of the sons of Israel that went into Egypt with their father Jacob—Jacob and his sons. The first-born of Jacob, Ruben.
+9|And the sons of Ruben; Enoch, and Phallus, Asron, and Charmi.
+10|and the sons of Symeon; Jemuel, and Jamin, and Aod, and Achin, and Saar, and Saul, the son of a Chananitish woman.
+11|And the sons of Levi; Gerson, Cath, and Merari.
+12|And the sons of Judas; Er, and Aunan, and Selom, and Phares, and Zara: and Er and Aunan died in the land of Chanaan.
+13|And the sons of Phares <i>were</i> Esron, and Jemuel. And the sons of Issachar; Thola, and Phua, and Asum, and Sambran.
+14|And the sons of Zabulun, Sered, and Allon, and Achoel.
+15|These <i>are</i> the sons of Lea, which she bore to Jacob in Mesopotamia of Syria, and Dina his daughter; all the souls, sons and daughters, thirty-three.
+16|And the sons of Gad; Saphon, and Angis, and Sannis, and Thasoban, and Aedis, and Aroedis, and Areelis.
+17|And the sons of Aser; Jemna, Jessua, and Jeul, and Baria, and Sara their sister. And the sons of Baria; Chobor, and Melchiil.
+18|These <i>are</i> the sons of Zelpha, which Laban gave to his daughter Lea, who bore these to Jacob, sixteen souls.
+19|And the sons of Rachel, the wife of Jacob; Joseph, and Benjamin.
+20|And there were sons born to Joseph in the land of Egypt, whom Aseneth, the daughter of Petephres, priest of Heliopolis, bore to him, <i>even</i> Manasses and Ephraim. And there were sons born to Manasses, which the Syrian concubine bore to him, <i>even</i> Machir. And Machir begot Galaad. And the sons of Ephraim, the brother of Manasses; Sutalaam, and Taam. And the sons of Sutalaam; Edom.
+21|and the sons of Benjamin; Bala, and Bochor, and Asbel. And the sons of Bala were Gera, and Noeman, and Anchis, and Ros, and Mamphim. And Gera begot Arad.
+22|These <i>are</i> the sons of Rachel, which she bore to Jacob; all the souls eighteen.
+23|And the sons of Dan; Asom.
+24|And the sons of Nephthalim; Asiel, and Goni, and Issaar, and Sollem.
+25|These <i>are</i> the sons of Balla, whom Laban gave to his daughter Rachel, who bore these to Jacob; all the souls, seven.
+26|And all the souls that came with Jacob into Egypt, who came out of his loins, besides the wives of the sons of Jacob, <i>even</i> all the souls were sixty-six.
+27|And the sons of Joseph, who were born to him in the land of Egypt, were nine souls; all the souls of the house of Jacob who came with Joseph into Egypt, were seventy-five souls.
+28|And he sent Judas before him to Joseph, to meet him to the city of Heroes, into the land of Ramesses.
+29|And Joseph having made ready his chariots, went up to meet Israel his father, at the city of Heroes; and having appeared to him, fell on his neck, and wept with abundant weeping.
+30|And Israel said to Joseph, After this I will <i>gladly</i> die, since I have seen thy face, for thou art yet living.
+31|And Joseph said to his brethren, I will go up and tell Pharao, and will say to him, My brethren, and my father's house, who were in the land of Chanaan, are come to me.
+32|And the men are shepherds; for they have been feeders of cattle, and they have brought with them their cattle, and their kine, and all their property.
+33|If then Pharao call you, and say to you, What is you occupation?
+34|Ye shall say, We thy servants are herdsmen from our youth until now, both we and our fathers: that ye may dwell in the land of Gesem of Arabia, for every shepherd is an abomination to the Egyptians.
 
 #47
-1| And Joseph came and told Pharao, <i>saying</i>, My father, and my brethren, and their cattle, and their oxen, and all their possessions, are come out of the land of Chanaan, and behold, they are in the land of Gesem. 
-2| And he took of his brethren five men, and set them before Pharao. 
-3| And Pharao said to the brethren of Joseph, What is your occupation? and they said to Pharao, Thy servants are shepherds, both we and our father. 
-4| And they said to Pharao, We are come to sojourn in the land, for there is no pasture for the flocks of thy servants, for the famine has prevailed in the land of Chanaan; now then, we will dwell in the land of Gesem. And Pharao said to Joseph, Let them dwell in the land of Gesem; and if thou knowest that there are among them able men, make them overseers of my cattle. So Jacob and his sons came into Egypt, to Joseph; and Pharao, king of Egypt, heard <i>of it</i>. 
-5| And Pharao spoke to Joseph, saying, Thy father, and thy brethren, are come to thee. 
-6| Behold, the land of Egypt is before thee; settle thy father and thy brethren in the best land. 
-7| And Joseph brought in Jacob his father, and set him before Pharao; and Jacob blessed Pharao. 
-8| And Pharao said to Jacob, How many are the years of the days of thy life? 
-9| And Jacob said to Pharao, The days of the years of my life, wherein I sojourn, are a hundred and thirty years; few and evil have been the days of the years of my life, they have not attained to the days of the life of my fathers, in which days they sojourned. 
-10| And Jacob blessed Pharao, and departed from him. 
-11| And Joseph settled his father and his brethren, and gave them a possession in the land of Egypt, in the best land, in the land of Ramesses, as Pharao commanded. 
-12| And Joseph gave provision to his father, and his brethren, and to all the house of his father, corn for each person. 	
-13| And there was no corn in all the land, for the famine prevailed greatly; and the land of Egypt, and the land of Chanaan, fainted for the famine. 
-14| And Joseph gathered all the money that was found in the land of Egypt, and the land of Chanaan, <i>in return for</i> the corn which they bought, and he distributed corn to them; and Joseph brought all the money into the house of Pharao. 
-15| And all the money failed out of the land of Egypt, and out of the land of Chanaan; and all the Egyptians came to Joseph, saying, Give us bread, and why do we die in thy presence? for our money is spent. 
-16| And Joseph said to them, Bring your cattle, and I will give you bread for your cattle, if your money is spent. 
-17| And they brought their cattle to Joseph; and Joseph gave them bread in return for their horses, and for their sheep, and for their oxen, and for their asses; and Joseph maintained them with bread for all their cattle in that year. 
-18| And that year passed, and they came to him in the second year, and said to him, Must we then be consumed from before our lord? for if our money has failed, and our possessions, and our cattle, <i>brought</i> to thee our lord, and there has not been left to us before our lord more than our own bodies and our land, <i>we are indeed destitute</i>. 
-19| In order, then, that we die not before thee, and the land be made desolate, buy us and our land for bread, and we and our land will be servants to Pharao: give seed that we may sow, and live and not die, so our land shall not be made desolate. 
-20| And Joseph bought all the land of the Egyptians, for Pharao; for the Egyptians sold their land to Pharao; for the famine prevailed against them, and the land became Pharao’s. 
-21| And he brought the people into bondage to him, for servants, from one extremity of Egypt to the other, 
-22| except only the land of the priests; Joseph bought not this, for Pharao gave a portion in the way of gift to the priests; and they ate their portion which Pharao gave them; therefore they sold not their land. 
-23| And Joseph said to all the Egyptians, Behold, I have bought you and your land this day for Pharao; take seed for you, and sow the land. 
-24| And there shall be the fruits of it; and ye shall give the fifth part to Pharao, and the four <i>remaining</i> parts shall be for yourselves, for seed for the earth, and for food for you, and all that are in your houses. 
-25| And they said, Thou hast saved us; we have found favour before our lord, and we will be servants to Pharao. 
-26| And Joseph appointed it to them for an ordinance until this day; to reserve a fifth part for Pharao, on the land of Egypt, except only the land of the priests, that was not Pharao’s. 	
-27| And Israel dwelt in Egypt, in the land of Gesem, and they gained an inheritance upon it; and they increased and multiplied very greatly. 
-28| And Jacob survived seventeen years in the land of Egypt; and Jacob’s days of the years of his life were a hundred and forty-seven years. 
-29| and the days of Israel drew nigh for him to die: and he called his son Joseph, and said to him, If I have found favour before thee, put thy hand under my thigh, and thou shalt execute mercy and truth toward me, so as not to bury me in Egypt. 
-30| But I will sleep with my fathers, and thou shalt carry me up out of Egypt, and bury me in their sepulchre. And he said, I will do according to thy word. 
-31| And he said, Swear to me; and he swore to him. And Israel did reverence, leaning on the top of his staff. 	8 	
+1|And Joseph came and told Pharao, <i>saying</i>, My father, and my brethren, and their cattle, and their oxen, and all their possessions, are come out of the land of Chanaan, and behold, they are in the land of Gesem.
+2|And he took of his brethren five men, and set them before Pharao.
+3|And Pharao said to the brethren of Joseph, What is your occupation? and they said to Pharao, Thy servants are shepherds, both we and our father.
+4|And they said to Pharao, We are come to sojourn in the land, for there is no pasture for the flocks of thy servants, for the famine has prevailed in the land of Chanaan; now then, we will dwell in the land of Gesem. And Pharao said to Joseph, Let them dwell in the land of Gesem; and if thou knowest that there are among them able men, make them overseers of my cattle. So Jacob and his sons came into Egypt, to Joseph; and Pharao, king of Egypt, heard <i>of it</i>.
+5|And Pharao spoke to Joseph, saying, Thy father, and thy brethren, are come to thee.
+6|Behold, the land of Egypt is before thee; settle thy father and thy brethren in the best land.
+7|And Joseph brought in Jacob his father, and set him before Pharao; and Jacob blessed Pharao.
+8|And Pharao said to Jacob, How many are the years of the days of thy life?
+9|And Jacob said to Pharao, The days of the years of my life, wherein I sojourn, are a hundred and thirty years; few and evil have been the days of the years of my life, they have not attained to the days of the life of my fathers, in which days they sojourned.
+10|And Jacob blessed Pharao, and departed from him.
+11|And Joseph settled his father and his brethren, and gave them a possession in the land of Egypt, in the best land, in the land of Ramesses, as Pharao commanded.
+12|And Joseph gave provision to his father, and his brethren, and to all the house of his father, corn for each person.
+13|And there was no corn in all the land, for the famine prevailed greatly; and the land of Egypt, and the land of Chanaan, fainted for the famine.
+14|And Joseph gathered all the money that was found in the land of Egypt, and the land of Chanaan, <i>in return for</i> the corn which they bought, and he distributed corn to them; and Joseph brought all the money into the house of Pharao.
+15|And all the money failed out of the land of Egypt, and out of the land of Chanaan; and all the Egyptians came to Joseph, saying, Give us bread, and why do we die in thy presence? for our money is spent.
+16|And Joseph said to them, Bring your cattle, and I will give you bread for your cattle, if your money is spent.
+17|And they brought their cattle to Joseph; and Joseph gave them bread in return for their horses, and for their sheep, and for their oxen, and for their asses; and Joseph maintained them with bread for all their cattle in that year.
+18|And that year passed, and they came to him in the second year, and said to him, Must we then be consumed from before our lord? for if our money has failed, and our possessions, and our cattle, <i>brought</i> to thee our lord, and there has not been left to us before our lord more than our own bodies and our land, <i>we are indeed destitute</i>.
+19|In order, then, that we die not before thee, and the land be made desolate, buy us and our land for bread, and we and our land will be servants to Pharao: give seed that we may sow, and live and not die, so our land shall not be made desolate.
+20|And Joseph bought all the land of the Egyptians, for Pharao; for the Egyptians sold their land to Pharao; for the famine prevailed against them, and the land became Pharao's.
+21|And he brought the people into bondage to him, for servants, from one extremity of Egypt to the other,
+22|except only the land of the priests; Joseph bought not this, for Pharao gave a portion in the way of gift to the priests; and they ate their portion which Pharao gave them; therefore they sold not their land.
+23|And Joseph said to all the Egyptians, Behold, I have bought you and your land this day for Pharao; take seed for you, and sow the land.
+24|And there shall be the fruits of it; and ye shall give the fifth part to Pharao, and the four <i>remaining</i> parts shall be for yourselves, for seed for the earth, and for food for you, and all that are in your houses.
+25|And they said, Thou hast saved us; we have found favour before our lord, and we will be servants to Pharao.
+26|And Joseph appointed it to them for an ordinance until this day; to reserve a fifth part for Pharao, on the land of Egypt, except only the land of the priests, that was not Pharao's.
+27|And Israel dwelt in Egypt, in the land of Gesem, and they gained an inheritance upon it; and they increased and multiplied very greatly.
+28|And Jacob survived seventeen years in the land of Egypt; and Jacob's days of the years of his life were a hundred and forty-seven years.
+29|and the days of Israel drew nigh for him to die: and he called his son Joseph, and said to him, If I have found favour before thee, put thy hand under my thigh, and thou shalt execute mercy and truth toward me, so as not to bury me in Egypt.
+30|But I will sleep with my fathers, and thou shalt carry me up out of Egypt, and bury me in their sepulchre. And he said, I will do according to thy word.
+31|And he said, Swear to me; and he swore to him. And Israel did reverence, leaning on the top of his staff.
 
 #48
-1| And it came to pass after these things, that it was reported to Joseph, Behold, thy father is ill; and, having taken his two sons, Manasse and Ephraim, he came to Jacob. 
-2| And it was reported to Jacob, saying, Behold, thy son Joseph cometh to thee; and Israel having strengthened himself, sat upon the bed. 
-3| And Jacob said to Joseph, My God appeared to me in Luza, in the land of Chanaan, and blessed me, 
-4| and said to me, Behold, I will increase thee, and multiply thee, and will make of thee multitudes of nations; and I will give this land to thee, and to thy seed after thee, for an everlasting possession. 
-5| Now then thy two sons, who were born to thee in the land of Egypt, before I came to thee into Egypt, are mine; Ephraim and Manasse, as Ruben and Symeon they shall be mine. 
-6| And the children which thou shalt beget hereafter, shall be in the name of their brethren; they shall be named after their inheritances. 
-7| And as for me, when I came out of Mesopotamia of Syria, Rachel, thy mother, died in the land of Chanaan, as I drew night to the horse-course of Chabratha of the land <i>of Chanaan</i>, so as to come to Ephratha; and I buried her in the road of the course; this is Bethlehem. 	
-8| And when Israel saw the sons of Joseph, he said, Who are these to thee? 
-9| And Joseph said to his father, They are my sons, whom God gave me here; and Jacob said, Bring me them, that I may bless them. 
-10| Now the eyes of Israel were dim through age, and he could not see; and he brought them near to him, and he kissed them, and embraced them. 
-11| And Israel said to Joseph, Behold, I have not been deprived of <i>seeing</i> thy face, and lo! God has showed me thy seed also. 
-12| And Joseph brought them out from <i>between</i> his knees, and they did reverence to him, with their face to the ground. 
-13| And Joseph took his two sons, both Ephraim in his right hand, but on the left of Israel, and Manasse on his left hand, but on the right of Israel, and brought them near to him. 
-14| But Israel having stretched out his right hand, laid it on the head of Ephraim, and he was the younger; and his left hand on the head of Manasse, <i>guiding</i> his hands crosswise.  	
-15| And he blessed them and said, The God in whose sight my fathers were well pleasing, <i>even</i> Abraam and Isaac, the God who continues to feed me from my youth until this day; 
-16| the angel who delivers me from all evils, bless these boys, and my name shall be called upon them, and the name of my fathers, Abraam and Isaac; and let them be increased to a great multitude on the earth. 
-17| And Joseph having seen that his father put his right hand on the head of Ephraim—it seemed grievous to him; and Joseph took hold of the hand of his father, to remove it from the head of Ephraim to the head of Manasse. 
-18| And Joseph said to his father, Not so, father; for this is the first-born; lay thy right-hand upon his head. 
-19| And he would not, but said, I know it, son, I know it; he also shall be a people, and he shall be exalted, but his younger brother shall be greater than he, and his seed shall become a multitude of nations. 
-20| And he blessed them in that day, saying, In you shall Israel be blessed, saying, God make thee as Ephraim and Manasse; and he set Ephraim before Manasse. 
-21| And Israel said to Joseph, Behold, I die; and God shall be with you, and restore you to the land of your fathers. 
-22| And I give to thee Sicima, a select portion above thy brethren, which I took out of the hand of the Amorites with my sword and bow. 	9 	
+1|And it came to pass after these things, that it was reported to Joseph, Behold, thy father is ill; and, having taken his two sons, Manasse and Ephraim, he came to Jacob.
+2|And it was reported to Jacob, saying, Behold, thy son Joseph cometh to thee; and Israel having strengthened himself, sat upon the bed.
+3|And Jacob said to Joseph, My God appeared to me in Luza, in the land of Chanaan, and blessed me,
+4|and said to me, Behold, I will increase thee, and multiply thee, and will make of thee multitudes of nations; and I will give this land to thee, and to thy seed after thee, for an everlasting possession.
+5|Now then thy two sons, who were born to thee in the land of Egypt, before I came to thee into Egypt, are mine; Ephraim and Manasse, as Ruben and Symeon they shall be mine.
+6|And the children which thou shalt beget hereafter, shall be in the name of their brethren; they shall be named after their inheritances.
+7|And as for me, when I came out of Mesopotamia of Syria, Rachel, thy mother, died in the land of Chanaan, as I drew night to the horse-course of Chabratha of the land <i>of Chanaan</i>, so as to come to Ephratha; and I buried her in the road of the course; this is Bethlehem.
+8|And when Israel saw the sons of Joseph, he said, Who are these to thee?
+9|And Joseph said to his father, They are my sons, whom God gave me here; and Jacob said, Bring me them, that I may bless them.
+10|Now the eyes of Israel were dim through age, and he could not see; and he brought them near to him, and he kissed them, and embraced them.
+11|And Israel said to Joseph, Behold, I have not been deprived of <i>seeing</i> thy face, and lo! God has showed me thy seed also.
+12|And Joseph brought them out from <i>between</i> his knees, and they did reverence to him, with their face to the ground.
+13|And Joseph took his two sons, both Ephraim in his right hand, but on the left of Israel, and Manasse on his left hand, but on the right of Israel, and brought them near to him.
+14|But Israel having stretched out his right hand, laid it on the head of Ephraim, and he was the younger; and his left hand on the head of Manasse, <i>guiding</i> his hands crosswise.
+15|And he blessed them and said, The God in whose sight my fathers were well pleasing, <i>even</i> Abraam and Isaac, the God who continues to feed me from my youth until this day;
+16|the angel who delivers me from all evils, bless these boys, and my name shall be called upon them, and the name of my fathers, Abraam and Isaac; and let them be increased to a great multitude on the earth.
+17|And Joseph having seen that his father put his right hand on the head of Ephraim—it seemed grievous to him; and Joseph took hold of the hand of his father, to remove it from the head of Ephraim to the head of Manasse.
+18|And Joseph said to his father, Not so, father; for this is the first-born; lay thy right-hand upon his head.
+19|And he would not, but said, I know it, son, I know it; he also shall be a people, and he shall be exalted, but his younger brother shall be greater than he, and his seed shall become a multitude of nations.
+20|And he blessed them in that day, saying, In you shall Israel be blessed, saying, God make thee as Ephraim and Manasse; and he set Ephraim before Manasse.
+21|And Israel said to Joseph, Behold, I die; and God shall be with you, and restore you to the land of your fathers.
+22|And I give to thee Sicima, a select portion above thy brethren, which I took out of the hand of the Amorites with my sword and bow.
 
 #49
-1| And Jacob called his sons, and said to them, 
-2| Assemble yourselves, that I may tell you what shall happen to you in the last days. Gather yourselves together, and hear me, sons of Jacob; hear Israel, hear your father. 
-3| Ruben, thou <i>art</i> my first-born, thou my strength, and the first of my children, hard to be endured, <i>hard and</i> self-willed. 
-4| Thou wast insolent like water, burst not forth with violence, for thou wentest up to the bed of thy father; then thou defiledst the couch, whereupon thou wentest up. 
-5| Symeon and Levi, brethren, accomplished the injustice of their cutting off. 
-6| Let not my soul come into their counsel, and let not mine inward parts contend in their conspiracy, for in their wrath they slew men, and in their passion they houghed a bull. 
-7| Cursed be their wrath, for it was willful, and their anger, for it was cruel: I will divide them in Jacob, and scatter them in Israel. 
-8| Juda, thy brethren have praised thee, and thy hands shall be on the back of thine enemies; thy father’s sons shall do thee reverence. 
-9| Juda is a lion’s whelp: from the tender plant, my son, thou art gone up, having couched thou liest as a lion, and as a whelp; who shall stir him up? 
-10| A ruler shall not fail from Juda, nor a prince from his loins, until there come the things stored up for him; and he is the expectation of nations. 
-11| Binding his foal to the vine, and the foal of his ass to the branch <i>of it</i>, he shall wash his robe in wine, and his garment in the blood of the grape. 
-12| His eyes shall be more cheering than wine, and his teeth whiter than milk. 
-13| Zabulon shall dwell on the coast, and he <i>shall be</i> by a haven of ships, and shall extend to Sidon. 
-14| Issachar has desired that which is good; resting between the inheritances. 
-15| And having seen the resting place that it was good, and the land that it was fertile, he subjected his shoulder to labour, and became a husbandman. 
-16| Dan shall judge his people, as one tribe too in Israel. 
-17| And let Dan be a serpent in the way, besetting the path, biting the heel of the horse (and the rider shall fall backward), 
-18| waiting for the salvation of the Lord. 
-19| Gad, a plundering troop shall plunder him; but he shall plunder him, <i>pursuing him</i> closely. 
-20| Aser, his bread <i>shall be</i> fat; and he shall yield dainties to princes. 
-21| Nephthalim is a spreading stem, bestowing beauty on its fruit. 
-22| Joseph is a son increased; my dearly loved son is increased; my youngest son, turn to me. 
-23| Against whom men taking evil counsel reproached <i>him</i>, and the archers pressed hard upon him. 
-24| But their bow and arrows were mightily consumed, and the sinews of their arms were slackened by the hand of the mighty one of Jacob; thence is he that strengthened Israel from the God of thy father; 
-25| and my God helped thee, and he blessed thee with the blessing of heaven from above, and the blessing of the earth possessing all things, because of the blessing of the breasts and of the womb, 
-26| the blessings of thy father and thy mother—it has prevailed above the blessing of the lasting mountains, and beyond the blessings of the everlasting hills; they shall be upon the head of Joseph, and upon the head of the brothers of whom he took the lead. 
-27| Benjamin, as a ravening wolf, shall eat still in the morning, and at evening he gives food. 
-28| All these <i>are</i> the twelve sons of Jacob; and their father spoke these words to them, and he blessed them; he blessed each of them according to his blessing. 
-29| And he said to them, I am added to my people; ye shall bury me with my fathers in the cave, which is in the field of Ephron the Chettite, 
-30| in the double cave which is opposite Mambre, in the land of Chanaan, the cave which Abraam bought of Ephron the Chettite, for a possession of a sepulchre. 
-31| There they buried Abraam and Sarrha his wife; there they buried Isaac, and Rebecca his wife; there they buried Lea; 
-32| in the portion of the field, and of the cave that was in it, <i>purchased</i> of the sons of Chet. 
-33| And Jacob ceased giving charges to his sons; and having lifted up his feet on the bed, he died, and was gathered to his people. 	0 	
+1|And Jacob called his sons, and said to them,
+2|Assemble yourselves, that I may tell you what shall happen to you in the last days. Gather yourselves together, and hear me, sons of Jacob; hear Israel, hear your father.
+3|Ruben, thou <i>art</i> my first-born, thou my strength, and the first of my children, hard to be endured, <i>hard and</i> self-willed.
+4|Thou wast insolent like water, burst not forth with violence, for thou wentest up to the bed of thy father; then thou defiledst the couch, whereupon thou wentest up.
+5|Symeon and Levi, brethren, accomplished the injustice of their cutting off.
+6|Let not my soul come into their counsel, and let not mine inward parts contend in their conspiracy, for in their wrath they slew men, and in their passion they houghed a bull.
+7|Cursed be their wrath, for it was willful, and their anger, for it was cruel: I will divide them in Jacob, and scatter them in Israel.
+8|Juda, thy brethren have praised thee, and thy hands shall be on the back of thine enemies; thy father's sons shall do thee reverence.
+9|Juda is a lion's whelp: from the tender plant, my son, thou art gone up, having couched thou liest as a lion, and as a whelp; who shall stir him up?
+10|A ruler shall not fail from Juda, nor a prince from his loins, until there come the things stored up for him; and he is the expectation of nations.
+11|Binding his foal to the vine, and the foal of his ass to the branch <i>of it</i>, he shall wash his robe in wine, and his garment in the blood of the grape.
+12|His eyes shall be more cheering than wine, and his teeth whiter than milk.
+13|Zabulon shall dwell on the coast, and he <i>shall be</i> by a haven of ships, and shall extend to Sidon.
+14|Issachar has desired that which is good; resting between the inheritances.
+15|And having seen the resting place that it was good, and the land that it was fertile, he subjected his shoulder to labour, and became a husbandman.
+16|Dan shall judge his people, as one tribe too in Israel.
+17|And let Dan be a serpent in the way, besetting the path, biting the heel of the horse (and the rider shall fall backward),
+18|waiting for the salvation of the Lord.
+19|Gad, a plundering troop shall plunder him; but he shall plunder him, <i>pursuing him</i> closely.
+20|Aser, his bread <i>shall be</i> fat; and he shall yield dainties to princes.
+21|Nephthalim is a spreading stem, bestowing beauty on its fruit.
+22|Joseph is a son increased; my dearly loved son is increased; my youngest son, turn to me.
+23|Against whom men taking evil counsel reproached <i>him</i>, and the archers pressed hard upon him.
+24|But their bow and arrows were mightily consumed, and the sinews of their arms were slackened by the hand of the mighty one of Jacob; thence is he that strengthened Israel from the God of thy father;
+25|and my God helped thee, and he blessed thee with the blessing of heaven from above, and the blessing of the earth possessing all things, because of the blessing of the breasts and of the womb,
+26|the blessings of thy father and thy mother—it has prevailed above the blessing of the lasting mountains, and beyond the blessings of the everlasting hills; they shall be upon the head of Joseph, and upon the head of the brothers of whom he took the lead.
+27|Benjamin, as a ravening wolf, shall eat still in the morning, and at evening he gives food.
+28|All these <i>are</i> the twelve sons of Jacob; and their father spoke these words to them, and he blessed them; he blessed each of them according to his blessing.
+29|And he said to them, I am added to my people; ye shall bury me with my fathers in the cave, which is in the field of Ephron the Chettite,
+30|in the double cave which is opposite Mambre, in the land of Chanaan, the cave which Abraam bought of Ephron the Chettite, for a possession of a sepulchre.
+31|There they buried Abraam and Sarrha his wife; there they buried Isaac, and Rebecca his wife; there they buried Lea;
+32|in the portion of the field, and of the cave that was in it, <i>purchased</i> of the sons of Chet.
+33|And Jacob ceased giving charges to his sons; and having lifted up his feet on the bed, he died, and was gathered to his people.
 
 #50
-1| And Joseph fell upon his father’s face, and wept on him, and kissed him. 
-2| And Joseph commanded his servants the embalmers to embalm his father; and the embalmers embalmed Israel. 
-3| And they fulfilled forty days for him, for so are the days of embalming numbered; and Egypt mourned for him seventy days. 
-4| And when the days of mourning were past, Joseph spoke to the princes of Pharao, saying, If I have found favour in your sight, speak concerning me in the ears of Pharao, saying, 
-5| My father adjured me, saying, In the sepulchre which I dug for myself in the land of Chanaan, there thou shalt bury me; now then I will go up and bury my father, and return again. 
-6| And Pharao said to Joseph, Go up, bury thy father, as he constrained thee to swear. 
-7| So Joseph went up to bury his father; and all the servants of Pharao went up with him, and the elders of his house, and all the elders of the land of Egypt. 
-8| And all the household of Joseph, and his brethren, and all the house of his father, and his kindred; and they left behind the sheep and the oxen in the land of Gesem. 
-9| And there went up with him also chariots and horsemen; and there was a very great company. 
-10| And they came to the threshing-floor of Atad, which is beyond Jordan; and they bewailed him with a great and very sore lamentation; and he made a mourning for his father seven days. 
-11| And the inhabitants of the land of Chanaan saw the mourning at the floor of Atad, and said, This is a great mourning to the Egyptians; therefore he called its name, The mourning of Egypt, which is beyond Jordan. 
-12| And thus his sons did to him. 
-13| So his sons carried him up into the land of Chanaan, and buried him in the double cave, which cave Abraam bought for possession of a burying place, of Ephrom the Chettite, before Mambre. 
-14| And Joseph returned to Egypt, he and his brethren, and those that had gone up with him to bury his father. 	
-15| And when the brethren of Joseph saw that their father was dead, they said, <i>Let us take heed</i>, lest at any time Joseph remember evil against us, and recompense to us all the evils which we have done against him. 
-16| And they came to Joseph, and said, Thy father adjured <i>us</i> before his death, saying, 
-17| Thus say ye to Joseph, Forgive them their injustice and their sin, forasmuch as they have done thee evil; and now pardon the injustice of the servants of the God of thy father. And Joseph wept while they spoke to him. 
-18| And they came to him and said, We, these <i>persons</i>, are thy servants. 
-19| And Joseph said to them, Fear not, for I am God’s. 
-20| Ye took counsel against me for evil, but God took counsel for me for good, that <i>the matter</i> might be as <i>it is</i> to-day, and much people might be fed. 
-21| And he said to them, Fear not, I will maintain you, and your families: and he comforted them, and spoke kindly to them. 
-22| And Joseph dwelt in Egypt, he and his brethren, and all the family of his father; and Joseph lived a hundred and ten years. 
-23| And Joseph saw the children of Ephraim to the third generation; and the sons of Machir the son of Manasse were borne on the sides of Joseph. 
-24| And Joseph spoke to his brethren, saying, I die, and God will surely visit you, and will bring you out of this land to the land concerning which God sware to our fathers, Abraam, Isaac, and Jacob. 
-25| And Joseph adjured the sons of Israel, saying, At the visitation with which God shall visit you, then ye shall carry up my bones hence with you. 
-
-26| And Joseph died, aged an hundred and ten years; and they prepared his corpse, and put him in a coffin in Egypt. 
+1|And Joseph fell upon his father's face, and wept on him, and kissed him.
+2|And Joseph commanded his servants the embalmers to embalm his father; and the embalmers embalmed Israel.
+3|And they fulfilled forty days for him, for so are the days of embalming numbered; and Egypt mourned for him seventy days.
+4|And when the days of mourning were past, Joseph spoke to the princes of Pharao, saying, If I have found favour in your sight, speak concerning me in the ears of Pharao, saying,
+5|My father adjured me, saying, In the sepulchre which I dug for myself in the land of Chanaan, there thou shalt bury me; now then I will go up and bury my father, and return again.
+6|And Pharao said to Joseph, Go up, bury thy father, as he constrained thee to swear.
+7|So Joseph went up to bury his father; and all the servants of Pharao went up with him, and the elders of his house, and all the elders of the land of Egypt.
+8|And all the household of Joseph, and his brethren, and all the house of his father, and his kindred; and they left behind the sheep and the oxen in the land of Gesem.
+9|And there went up with him also chariots and horsemen; and there was a very great company.
+10|And they came to the threshing-floor of Atad, which is beyond Jordan; and they bewailed him with a great and very sore lamentation; and he made a mourning for his father seven days.
+11|And the inhabitants of the land of Chanaan saw the mourning at the floor of Atad, and said, This is a great mourning to the Egyptians; therefore he called its name, The mourning of Egypt, which is beyond Jordan.
+12|And thus his sons did to him.
+13|So his sons carried him up into the land of Chanaan, and buried him in the double cave, which cave Abraam bought for possession of a burying place, of Ephrom the Chettite, before Mambre.
+14|And Joseph returned to Egypt, he and his brethren, and those that had gone up with him to bury his father.
+15|And when the brethren of Joseph saw that their father was dead, they said, <i>Let us take heed</i>, lest at any time Joseph remember evil against us, and recompense to us all the evils which we have done against him.
+16|And they came to Joseph, and said, Thy father adjured <i>us</i> before his death, saying,
+17|Thus say ye to Joseph, Forgive them their injustice and their sin, forasmuch as they have done thee evil; and now pardon the injustice of the servants of the God of thy father. And Joseph wept while they spoke to him.
+18|And they came to him and said, We, these <i>persons</i>, are thy servants.
+19|And Joseph said to them, Fear not, for I am God's.
+20|Ye took counsel against me for evil, but God took counsel for me for good, that <i>the matter</i> might be as <i>it is</i> to-day, and much people might be fed.
+21|And he said to them, Fear not, I will maintain you, and your families: and he comforted them, and spoke kindly to them.
+22|And Joseph dwelt in Egypt, he and his brethren, and all the family of his father; and Joseph lived a hundred and ten years.
+23|And Joseph saw the children of Ephraim to the third generation; and the sons of Machir the son of Manasse were borne on the sides of Joseph.
+24|And Joseph spoke to his brethren, saying, I die, and God will surely visit you, and will bring you out of this land to the land concerning which God sware to our fathers, Abraam, Isaac, and Jacob.
+25|And Joseph adjured the sons of Israel, saying, At the visitation with which God shall visit you, then ye shall carry up my bones hence with you.
+26|And Joseph died, aged an hundred and ten years; and they prepared his corpse, and put him in a coffin in Egypt.


### PR DESCRIPTION
 - Remove leading whitespace that caused verses to not render
 - Remove trailing whitespace
 - Remove extraneous numbers at the end of chapters